### PR TITLE
🎨 Improve documentation for how pre-push hooks work

### DIFF
--- a/templates/pre-push
+++ b/templates/pre-push
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -e
 
+# Delegating script for multiple git pre-push hooks
+# This file will call any other pre-push.* files *except* pre-push.sample
+#
+# Called by "git push" after it has checked the remote status,
+# but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+
 # Get the path to the directory containing this script.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/templates/pre-push.lint
+++ b/templates/pre-push.lint
@@ -3,6 +3,23 @@ set -e
 
 # A pre-push hook to run khan-linter before pushing, and abort if lint fails.
 # For emergencies, you can override this hook by using 'git push --no-verify'.
+#
+# Called by "git push" after it has checked the remote status,
+# but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be the URL twice.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
 
 PATH_CMD="_ka-commit-lint"
 OLD_PATH="$HOME/khan/devtools/khan-linter/githook.py"


### PR DESCRIPTION
I added the comments for the somewhat obscure details of how you can only have one of each type of git hook (so you need to make one a delegation to others), and how pre-push hooks need to be parsed differently than other hooks, due to the unique stdin input.

Issue: none

Test plan:

Signed-off-by: Steve Coffman <steve@khanacademy.org>