### PR TITLE
Turn off commit-msg hook enforcing certain commit format, and add branch name prepender

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -153,7 +153,7 @@ def install_lint_hooks():
     #     install it directly as the single commit-msg executable. If we add
     #     more commit-msg hooks later, we'll need to create an executable that
     #     delegates to all of them, like we do for pre-push.
-    _install_git_hook('commit-msg.lint', 'commit-msg')
+    _install_git_hook('commit-msg.lint', 'commit-msg.lint')
     _install_git_hook('pre-push.lint', 'pre-push.lint')
 
     _cli_log_step_success("Added linting hooks")
@@ -171,6 +171,7 @@ def install_global_git_hooks():
     #     installed, then this pre-push hook is a no-op. So, this hook is
     #     always safe to install, regardless of the ka-clone arguments.
     _install_git_hook('pre-push', 'pre-push')
+    _install_git_hook('commit-msg', 'commit-msg')
 
 
 def _install_git_hook(template_name, destination_name):

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -149,11 +149,6 @@ def protect_master():
 
 
 def install_lint_hooks():
-    # NOTE(mdr): This is currently the only commit-msg hook, so it's safe to
-    #     install it directly as the single commit-msg executable. If we add
-    #     more commit-msg hooks later, we'll need to create an executable that
-    #     delegates to all of them, like we do for pre-push.
-    _install_git_hook('commit-msg.lint', 'commit-msg.lint')
     _install_git_hook('pre-push.lint', 'pre-push.lint')
 
     _cli_log_step_success("Added linting hooks")

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -35,7 +35,7 @@ def _cli_parser():
     parser.add_argument('-p', '--protect-master',
                         action='store_true',
                         help='install hooks to protect the master branch')
-    parser.add_argument('--branch-name',
+    parser.add_argument('--branch-name-hook',
                         action='store_true',
                         help='prepend commit-msgs with the current branch name')
     parser.add_argument('--lint-commit',
@@ -300,7 +300,7 @@ def _cli_process_current_dir(cli_args):
     if cli_args.lint_commit:
         _install_git_hook('commit-msg.lint', 'commit-msg.lint')
         _cli_log_step_success("Added commit-msg lint hook")
-    if cli_args.branch_name:
+    if cli_args.branch_name_hook:
         _install_git_hook('commit-msg.branch-name', 'commit-msg.branch-name')
         _cli_log_step_success("Added commit-msg branch-name hook")
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -28,13 +28,19 @@ def _cli_parser():
                         help=argparse.SUPPRESS,
                         nargs='?')
     # operational changes
-    parser.add_argument('-p', '--protect-master',
-                        action='store_true',
-                        help='install hooks to protect the master branch')
     parser.add_argument('--repair',
                         action='store_true',
                         help='attempt to khanify the current directory')
-    # disable functions
+    # enable/disable functions
+    parser.add_argument('-p', '--protect-master',
+                        action='store_true',
+                        help='install hooks to protect the master branch')
+    parser.add_argument('--branch-name',
+                        action='store_true',
+                        help='prepend commit-msgs with the current branch name')
+    parser.add_argument('--lint-commit',
+                        action='store_true',
+                        help='hook up commit-msg linting')
     parser.add_argument('--no-email',
                         action='store_true',
                         help='do not override user.email')
@@ -43,7 +49,7 @@ def _cli_parser():
                         help='do not link KA gitconfig extras')
     parser.add_argument('--no-lint',
                         action='store_true',
-                        help='do not hook commit-msg linting')
+                        help='do not hook pre-push linting')
     parser.add_argument('--no-msg',
                         action='store_true',
                         help='no commit message template')
@@ -148,10 +154,9 @@ def protect_master():
     _cli_log_step_success("Added hooks to protect master branch")
 
 
-def install_lint_hooks():
+def install_pre_push_lint_hook():
     _install_git_hook('pre-push.lint', 'pre-push.lint')
-
-    _cli_log_step_success("Added linting hooks")
+    _cli_log_step_success("Added pre-push linting hook")
 
 
 def _git_dir():
@@ -284,13 +289,21 @@ def _cli_process_current_dir(cli_args):
     if not cli_args.no_email:
         set_email(args.email)
     if not cli_args.no_lint:
-        install_lint_hooks()
+        install_pre_push_lint_hook()
     if not cli_args.no_msg:
         link_commit_template()
     if not cli_args.no_gitconfig:
         link_gitconfig_extras()
+
     if cli_args.protect_master:
         protect_master()
+    if cli_args.lint_commit:
+        _install_git_hook('commit-msg.lint', 'commit-msg.lint')
+        _cli_log_step_success("Added commit-msg lint hook")
+    if cli_args.branch_name:
+        _install_git_hook('commit-msg.branch-name', 'commit-msg.branch-name')
+        _cli_log_step_success("Added commit-msg branch-name hook")
+
     install_global_git_hooks()
 
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -294,7 +294,6 @@ def _cli_process_current_dir(cli_args):
     install_global_git_hooks()
 
 
-
 if __name__ == '__main__':
     parser = _cli_parser()
     args = parser.parse_args()

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -174,6 +174,14 @@ def install_global_git_hooks():
     _install_git_hook('commit-msg', 'commit-msg')
 
 
+def _remove_git_hook(destination_name):
+    """Remove a git hook from the CWD's git repo."""
+    hooks_dir = os.path.join(_git_dir(), "hooks")
+    dst = os.path.join(hooks_dir, destination_name)
+    if os.path.exists(dst):
+        os.unlink(dst)
+
+
 def _install_git_hook(template_name, destination_name):
     """Install a template as an executable git hook into the CWD's git repo."""
     src = os.path.join(TEMPLATES_DIR, template_name)
@@ -297,12 +305,18 @@ def _cli_process_current_dir(cli_args):
 
     if cli_args.protect_master:
         protect_master()
+
     if cli_args.lint_commit:
         _install_git_hook('commit-msg.lint', 'commit-msg.lint')
         _cli_log_step_success("Added commit-msg lint hook")
+    else:
+        _remove_git_hook('commit-msg.lint')
+
     if cli_args.branch_name_hook:
         _install_git_hook('commit-msg.branch-name', 'commit-msg.branch-name')
         _cli_log_step_success("Added commit-msg branch-name hook")
+    else:
+        _remove_git_hook('commit-msg.branch-name')
 
     install_global_git_hooks()
 

--- a/templates/commit-msg
+++ b/templates/commit-msg
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# The commit-msg receives one parameter; the pathname to a temporary file
+# containing the user's commit message.
+
+# This script prepends the current branch name to the commit message, which
+# greatly aids in workflows where you are juggling commits from multiple
+# branches, as when managing stacked diffs in the github workflow.
+
+if [ -z "$BRANCHES_TO_SKIP" ]; then
+  BRANCHES_TO_SKIP=(master develop test main)
+fi
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+
+BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
+BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
+
+if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then 
+  BRANCH_NAME="${BRANCH_NAME//\//\\/}"
+  sed -i.bak -e "1s/^/[$BRANCH_NAME] /" $1
+fi
+
+
+# If you want to lint the commit message as well, uncomment this line
+# . "$(dirname "${BASH_SOURCE[0]}")/commit-msg.lint"

--- a/templates/commit-msg
+++ b/templates/commit-msg
@@ -4,24 +4,19 @@ set -e
 # The commit-msg receives one parameter; the pathname to a temporary file
 # containing the user's commit message.
 
-# This script prepends the current branch name to the commit message, which
-# greatly aids in workflows where you are juggling commits from multiple
-# branches, as when managing stacked diffs in the github workflow.
+# Get the path to the directory containing this script.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$BRANCHES_TO_SKIP" ]; then
-  BRANCHES_TO_SKIP=(master develop test main)
-fi
+# Configure "commit-msg.*" to resolve to an empty set if there are no matches,
+# instead of the string "commit-msg.*".
+shopt -s nullglob
 
-BRANCH_NAME=$(git symbolic-ref --short HEAD)
-
-BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
-BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
-
-if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then 
-  BRANCH_NAME="${BRANCH_NAME//\//\\/}"
-  sed -i.bak -e "1s/^/[$BRANCH_NAME] /" $1
-fi
-
-
-# If you want to lint the commit message as well, uncomment this line
-# . "$(dirname "${BASH_SOURCE[0]}")/commit-msg.lint"
+# Execute all commit-msg.* handlers.
+for hook_handler in $DIR/commit-msg.*; do
+    # Some people have a `commit-msg.sample` file that is in `.git/hooks` by
+    # default. Ignore that so that file so that we don't run the sample hook.
+    if [ "`basename "$hook_handler"`" != "commit-msg.sample" ]
+    then
+        "$hook_handler" "$@"
+    fi
+done

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# This script prepends the current branch name to the commit message, which
+# greatly aids in workflows where you are juggling commits from multiple
+# branches, as when managing stacked diffs in the github workflow.
+
+if [ -z "$BRANCHES_TO_SKIP" ]; then
+  BRANCHES_TO_SKIP=(master develop test main)
+fi
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+
+BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
+BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
+
+if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then 
+  BRANCH_NAME="${BRANCH_NAME//\//\\/}"
+  sed -i.bak -e "1s/^/[$BRANCH_NAME] /" $1
+fi

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 # This script prepends the current branch name to the commit message, which
 # greatly aids in workflows where you are juggling commits from multiple

--- a/templates/commit-msg.lint
+++ b/templates/commit-msg.lint
@@ -1,6 +1,4 @@
 #!/bin/sh
-# NOTE: This linter is disabled by default. If you want to enable it,
-# uncomment the last line of the `commit-msg` hook.
 
 # A simple commit-msg hook that runs khan-linter's git hook.  Attempts to use
 # a version of khan-linter found in $PATH, if not, falls back to the old style

--- a/templates/commit-msg.lint
+++ b/templates/commit-msg.lint
@@ -1,4 +1,6 @@
 #!/bin/sh
+# NOTE: This linter is disabled by default. If you want to enable it,
+# uncomment the last line of the `commit-msg` hook.
 
 # A simple commit-msg hook that runs khan-linter's git hook.  Attempts to use
 # a version of khan-linter found in $PATH, if not, falls back to the old style


### PR DESCRIPTION
## Summary:
Both are disabled by default.

Issue: https://khanacademy.atlassian.net/browse/FEI-3686

## Test plan:
- run `./bin/ka-clone --repair`
- write a one-line commit message, and it should succeed!
- run `./bin/ka-clone --repair --branch-name-hook`
- `git checkout -b some-branch`
- `git commit --allow-empty -m hello`
- `git log` should show that the branch name has been prepended!