### PR TITLE
[🔥AUDIT🔥] Fix ka-clone to work with python3.

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import argparse
 import logging
@@ -82,7 +82,7 @@ def _cli_log_step_warning(msg):
 def die_if_not_valid_git_repo():
     revparse_retcode = subprocess.call(["git", "rev-parse"])
     # subprocess.call echos STDERR, so no need to log on error condition
-    if revparse_retcode is not 0:
+    if revparse_retcode != 0:
         sys.exit(revparse_retcode)
 
 
@@ -100,7 +100,7 @@ def _run_in_main_repo_and_subrepos(cmd):
     # not have been checked out yet.
     all_submodules = subprocess.check_output(
         ['git', 'submodule', 'status', '--recursive']
-    )
+    ).decode('utf-8')
     all_dirs = [l.split()[1] for l in all_submodules.splitlines()]
     all_dirs.append('.')      # do the main repo as well!
 
@@ -113,7 +113,9 @@ def _run_in_main_repo_and_subrepos(cmd):
 
 def _default_email():
     try:
-        kac_email = subprocess.check_output(["git", "config", "kaclone.email"])
+        kac_email = subprocess.check_output(
+            ["git", "config", "kaclone.email"]
+        ).decode('utf-8')
         return kac_email.rstrip()
     except subprocess.CalledProcessError:
         return os.environ['USER'] + "@" + DEFAULT_EMAIL_DOMAIN
@@ -161,7 +163,9 @@ def install_pre_push_lint_hook():
 
 def _git_dir():
     """Retrieve the GIT_DIR from the system."""
-    return subprocess.check_output(["git", "rev-parse", "--git-dir"]).rstrip()
+    return subprocess.check_output(
+        ["git", "rev-parse", "--git-dir"]
+    ).decode('utf-8').rstrip()
 
 
 def install_global_git_hooks():
@@ -193,7 +197,7 @@ def _install_git_hook(template_name, destination_name):
     if os.path.islink(dst):
         os.unlink(dst)
     shutil.copy(src, dst)
-    os.chmod(dst, (os.stat(dst)).st_mode | 0111)  # ensure chmod +x
+    os.chmod(dst, (os.stat(dst)).st_mode | 0o111)  # ensure chmod +x
 
 
 def link_commit_template():
@@ -250,7 +254,7 @@ def _clone_repo(src, dst, quiet=False):
     cmds.append(dst)
 
     retcode = subprocess.call(cmds)
-    if retcode is not 0:
+    if retcode != 0:
         sys.exit(retcode)
 
     # Initialize submodules, so we can set configs on them too.
@@ -259,7 +263,7 @@ def _clone_repo(src, dst, quiet=False):
         cmds.append('--quiet')
     cmds.extend(['update', '--init', '--recursive'])
     retcode = subprocess.call(cmds, cwd=dst)
-    if retcode is not 0:
+    if retcode != 0:
         sys.exit(retcode)
 
     return dst


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I used 2to3 to do the conversion, but had to fix up all the subprocess
calls myself.  There was also a warning that showed up when I ran the
script, involving `!=` vs `is not`, that I fixed as well.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9771

## Test plan:
I ran these with success:
```
cd /tmp
~/khan/devtools/ka-clone/bin/ka-clone git@github.com:Khan/ka-clone
cd ka-clone
~/khan/devtools/ka-clone/bin/ka-clone --repair
```