### PR TITLE
Update branch-name commit-msg hook, so when you use a commit template, and quit without changing it, the commit is aborted

### DIFF
--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -8,12 +8,14 @@ if [ -z "$BRANCHES_TO_SKIP" ]; then
   BRANCHES_TO_SKIP=(master develop test main)
 fi
 
+#testing
+
 BRANCH_NAME=$(git symbolic-ref --short HEAD)
 
 BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
 BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
 
-if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then 
+if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
   BRANCH_NAME="${BRANCH_NAME//\//\\/}"
   sed -i.bak -e "1s/^/[$BRANCH_NAME] /" $1
 fi

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -1,47 +1,51 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # This script prepends the current branch name to the commit message, which
 # greatly aids in workflows where you are juggling commits from multiple
 # branches, as when managing stacked diffs in the github workflow.
 
-if [ -z "$BRANCHES_TO_SKIP" ]; then
-  BRANCHES_TO_SKIP=(master develop test main)
-fi
+# TODO (Lilli): Eventually, rewrite this script to function like commit-msg.lint
+# where it just calls khan-linter with the appropriate flags, and the linter
+# can do the work of checking if the commit message is empty or unchanged (as
+# well as adding the branch-name). For now, I'll leave this as it is, since
+# that change requires that users also bring down updated code from khan-linter
+# and I'm trying to take a light touch atm.
 
-
-BRANCH_NAME=$(git symbolic-ref --short HEAD)
-
-BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
-BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
 
 # Get the commit template path from git config
 COMMIT_TEMPLATE_PATH=$(git config --get commit.template)
 
 # Check if the commit template path is set
 if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
-  # Read the commit message file and filter out comment lines and empty lines
-  COMMIT_MSG=$(grep -v '^#' "$1" | sed '/^[[:space:]]*$/d')
-
   # Expand the commit template path
-  COMMIT_TEMPLATE_PATH=$(eval echo "$COMMIT_TEMPLATE_PATH")
+  COMMIT_TEMPLATE_PATH="${COMMIT_TEMPLATE_PATH/#\~/$HOME}"
 
   # Read the commit template file
-  if [ -f "$COMMIT_TEMPLATE_PATH" ]; then
-    COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
-  else
-    echo "Commit template file not found at $COMMIT_TEMPLATE_PATH"
-    exit 1
-  fi
+  COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH" 2>/dev/null)
 
-  # Filter out comment lines and empty lines from the commit template
-  COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | grep -v '^#' | sed '/^[[:space:]]*$/d')
+  if [ -n "$COMMIT_TEMPLATE" ]; then
+    # Read the commit message file and filter out comment lines and empty lines
+    COMMIT_MSG=$(grep -v '^#' "$1" | sed '/^[[:space:]]*$/d')
 
-  # Check if the commit message matches the commit template
-  if [ "$COMMIT_MSG" = "$COMMIT_TEMPLATE" ]; then
-    echo "Aborting commit due to default commit message."
-    exit 1
+    # Filter out comment lines and empty lines from the commit template
+    COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | grep -v '^#' | sed '/^[[:space:]]*$/d')
+
+    # Check if the commit message matches the commit template
+    if [ "$COMMIT_MSG" = "$COMMIT_TEMPLATE" ]; then
+      echo "Aborting commit due to default commit message."
+      exit 1
+    fi
   fi
 fi
+
+if [ -z "$BRANCHES_TO_SKIP" ]; then
+  BRANCHES_TO_SKIP=(master develop test main)
+fi
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+
+BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
+BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
 
 if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
   BRANCH_NAME="${BRANCH_NAME//\//\\/}"

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -19,12 +19,8 @@ COMMIT_TEMPLATE_PATH=$(git config --get commit.template)
 
 # Check if the commit template path is set
 if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
-  echo "Using commit template: $COMMIT_TEMPLATE_PATH"
-
   # Read the commit message file and filter out comment lines and empty lines
   COMMIT_MSG=$(grep -v '^#' "$1" | sed '/^[[:space:]]*$/d')
-
-  echo "COMMIT_MSG: $COMMIT_MSG"
 
   # Expand the commit template path
   COMMIT_TEMPLATE_PATH=$(eval echo "$COMMIT_TEMPLATE_PATH")

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -8,12 +8,30 @@ if [ -z "$BRANCHES_TO_SKIP" ]; then
   BRANCHES_TO_SKIP=(master develop test main)
 fi
 
-#testing
 
 BRANCH_NAME=$(git symbolic-ref --short HEAD)
 
 BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
 BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
+
+# Get the commit template path from git config
+COMMIT_TEMPLATE_PATH=$(git config --get commit.template)
+
+# Check if the commit template path is set
+if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
+  # Read the commit template file
+  COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
+
+  # Read the commit message file
+  COMMIT_MSG=$(cat "$1")
+
+  # Check if the commit message matches the commit template
+  if [ "$COMMIT_MSG" = "$COMMIT_TEMPLATE" ]; then
+    echo "Aborting commit due to default commit message."
+    exit 1
+  fi
+fi
+
 
 if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
   BRANCH_NAME="${BRANCH_NAME//\//\\/}"

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -20,21 +20,22 @@ COMMIT_TEMPLATE_PATH=$(git config --get commit.template)
 # Check if the commit template path is set
 if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
   echo "Using commit template: $COMMIT_TEMPLATE_PATH"
-  echo "COMMIT_MSG: $1"
 
   # Read the commit message file
   COMMIT_MSG=$(cat "$1")
 
-  # Expand the commit template path
-    COMMIT_TEMPLATE_PATH=$(eval echo "$COMMIT_TEMPLATE_PATH")
+  echo "COMMIT_MSG: $1"
 
-    # Read the commit template file
-    if [ -f "$COMMIT_TEMPLATE_PATH" ]; then
-      COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
-    else
-      echo "Commit template file not found at $COMMIT_TEMPLATE_PATH"
-      exit 1
-    fi
+  # Expand the commit template path
+  COMMIT_TEMPLATE_PATH=$(eval echo "$COMMIT_TEMPLATE_PATH")
+
+  # Read the commit template file
+  if [ -f "$COMMIT_TEMPLATE_PATH" ]; then
+    COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
+  else
+    echo "Commit template file not found at $COMMIT_TEMPLATE_PATH"
+    exit 1
+  fi
 
   # Check if the commit message matches the commit template
   if [ "$COMMIT_MSG" = "$COMMIT_TEMPLATE" ]; then

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -24,7 +24,7 @@ if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
   # Read the commit message file
   COMMIT_MSG=$(cat "$1")
 
-  echo "COMMIT_MSG: $1"
+  echo "COMMIT_MSG: $COMMIT_MSG"
 
   # Expand the commit template path
   COMMIT_TEMPLATE_PATH=$(eval echo "$COMMIT_TEMPLATE_PATH")

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -19,6 +19,9 @@ COMMIT_TEMPLATE_PATH=$(git config --get commit.template)
 
 # Check if the commit template path is set
 if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
+  echo "Using commit template: $COMMIT_TEMPLATE_PATH"
+  echo "COMMIT_MSG: $1"
+
   # Read the commit template file
   COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
 

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -22,11 +22,19 @@ if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
   echo "Using commit template: $COMMIT_TEMPLATE_PATH"
   echo "COMMIT_MSG: $1"
 
-  # Read the commit template file
-  COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
-
   # Read the commit message file
   COMMIT_MSG=$(cat "$1")
+
+  # Expand the commit template path
+    COMMIT_TEMPLATE_PATH=$(eval echo "$COMMIT_TEMPLATE_PATH")
+
+    # Read the commit template file
+    if [ -f "$COMMIT_TEMPLATE_PATH" ]; then
+      COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
+    else
+      echo "Commit template file not found at $COMMIT_TEMPLATE_PATH"
+      exit 1
+    fi
 
   # Check if the commit message matches the commit template
   if [ "$COMMIT_MSG" = "$COMMIT_TEMPLATE" ]; then

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -21,8 +21,8 @@ COMMIT_TEMPLATE_PATH=$(git config --get commit.template)
 if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
   echo "Using commit template: $COMMIT_TEMPLATE_PATH"
 
-  # Read the commit message file
-  COMMIT_MSG=$(cat "$1")
+  # Read the commit message file and filter out comment lines and empty lines
+  COMMIT_MSG=$(grep -v '^#' "$1" | sed '/^[[:space:]]*$/d')
 
   echo "COMMIT_MSG: $COMMIT_MSG"
 
@@ -31,12 +31,14 @@ if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
 
   # Read the commit template file
   if [ -f "$COMMIT_TEMPLATE_PATH" ]; then
-    # Filter out comment lines and empty lines from the commit template
-    COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | grep -v '^#' | sed '/^[[:space:]]*$/d')
+    COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
   else
     echo "Commit template file not found at $COMMIT_TEMPLATE_PATH"
     exit 1
   fi
+
+  # Filter out comment lines and empty lines from the commit template
+  COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | grep -v '^#' | sed '/^[[:space:]]*$/d')
 
   # Check if the commit message matches the commit template
   if [ "$COMMIT_MSG" = "$COMMIT_TEMPLATE" ]; then
@@ -44,7 +46,6 @@ if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
     exit 1
   fi
 fi
-
 
 if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
   BRANCH_NAME="${BRANCH_NAME//\//\\/}"

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -31,7 +31,8 @@ if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
 
   # Read the commit template file
   if [ -f "$COMMIT_TEMPLATE_PATH" ]; then
-    COMMIT_TEMPLATE=$(cat "$COMMIT_TEMPLATE_PATH")
+    # Filter out comment lines and empty lines from the commit template
+    COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | grep -v '^#' | sed '/^[[:space:]]*$/d')
   else
     echo "Commit template file not found at $COMMIT_TEMPLATE_PATH"
     exit 1


### PR DESCRIPTION
## Summary:
See this comment here: https://github.com/Khan/ka-clone/pull/4#pullrequestreview-721580768

Issue: FEI-3822

## Test plan:
1. Have the `commit-msg.branch-name` hook enabled
2. Run `git commit -a`
3. Save template without changing anything
4. See that commit is aborted

More tests:
- Repeat the above with extra blank lines at the start and end of the commit message
- ... with extra blank lines at the start and end of the commit template
- ... with extra comment lines at the start and end of the commit message
- ... with extra comment lines at the start and end of the commit template

Make sure it runs when `git config commit.template` is
- unset
- globally set
- a relative link to the working dir (`<path-to-template>`)
- a relative link to the working dir with a dot/two dots (`./<path-to-template>`, `../<path-to-template>`)
- a relative link to the home dir (`~/<path-to-template>`)
- an absolute link (`/Users/lilli/<path-to-template>`)