### PR TITLE
Also abort if the commit message is empty

### DIFF
--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -11,6 +11,12 @@
 # that change requires that users also bring down updated code from khan-linter
 # and I'm trying to take a light touch atm.
 
+COMMIT_MSG=$(grep -v '^#' "$1" | sed '/^[[:space:]]*$/d')
+
+if [ -z "$COMMIT_MSG" ]; then
+  echo "Aborting commit due to empty commit message."
+  exit 1
+fi
 
 # Get the commit template path from git config
 COMMIT_TEMPLATE_PATH=$(git config --get commit.template)
@@ -25,7 +31,6 @@ if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
 
   if [ -n "$COMMIT_TEMPLATE" ]; then
     # Read the commit message file and filter out comment lines and empty lines
-    COMMIT_MSG=$(grep -v '^#' "$1" | sed '/^[[:space:]]*$/d')
 
     # Filter out comment lines and empty lines from the commit template
     COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | grep -v '^#' | sed '/^[[:space:]]*$/d')

--- a/templates/commit-msg.branch-name
+++ b/templates/commit-msg.branch-name
@@ -11,7 +11,7 @@
 # that change requires that users also bring down updated code from khan-linter
 # and I'm trying to take a light touch atm.
 
-COMMIT_MSG=$(grep -v '^#' "$1" | sed '/^[[:space:]]*$/d')
+COMMIT_MSG=$(sed -e '/^[[:space:]]*$/d' -e '/^#/d' "$1")
 
 if [ -z "$COMMIT_MSG" ]; then
   echo "Aborting commit due to empty commit message."
@@ -33,7 +33,7 @@ if [ -n "$COMMIT_TEMPLATE_PATH" ]; then
     # Read the commit message file and filter out comment lines and empty lines
 
     # Filter out comment lines and empty lines from the commit template
-    COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | grep -v '^#' | sed '/^[[:space:]]*$/d')
+    COMMIT_TEMPLATE=$(echo "$COMMIT_TEMPLATE" | sed -e '/^[[:space:]]*$/d' -e '/^#/d')
 
     # Check if the commit message matches the commit template
     if [ "$COMMIT_MSG" = "$COMMIT_TEMPLATE" ]; then


### PR DESCRIPTION
## Summary:
<Add your summary here>

Issue: FEI-3822

## Test plan:
1. Have the `commit-msg.branch-name` hook enabled
2. Run `git commit -a`
3. Delete everything but blank lines, comments, and whitespace
4. See that commit is aborted