### PR TITLE
The pre-commit.protect-master should protect more than just master

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -144,6 +144,7 @@ def protect_master():
     _install_git_hook('pre-commit.protect-master', 'pre-commit')
     _install_git_hook('pre-push.protect-master', 'pre-push.protect-master')
     _install_git_hook('pre-rebase.protect-master', 'pre-rebase')
+
     # Make a note in the local git config -- e.g. git-review-branch uses this
     # to check if it should allow you to branch off master.
     # TODO(benkraft): Read this value as a default for the commandline

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -24,7 +24,7 @@ KNOWN_DEPLOY_BRANCHES=$(git config --get ka.olc.targetBranches)
 
 # Check if the current branch is protected
 case "$CURRENT_BRANCH" in
-    master|main|next|deploy*)
+    master|main|next)
         echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
         echo "More info: https://khanacademy.org/r/gitfaq#id-9e3a"
         exit 1

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -26,7 +26,6 @@ KNOWN_DEPLOY_BRANCHES=$(git config --get ka.olc.targetBranches)
 case "$CURRENT_BRANCH" in
     master|main|next|deploy*)
         echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
-        echo "Make a pull-request or audit to a deploy branch instead: https://khanacademy.org/r/git-at-ka"
         exit 1
         ;;
 esac
@@ -36,7 +35,7 @@ IFS=','
 for branch in $KNOWN_DEPLOY_BRANCHES; do
     if [ "$CURRENT_BRANCH" = "$branch" ]; then
         echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
-        echo "Make a pull-request or audit to a deploy branch instead: https://khanacademy.org/r/git-at-ka"
+        echo "Make a pull-request or audit and land it to this branch instead"
         exit 1
     fi
 done

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# A simple pre-commit hook that makes it illegal to commit to master
-# on the repo.  An exception is made for the automated process
-# which is the only thing allowed to merge into master.
+# A simple pre-commit hook that makes it illegal to commit to master (and other
+# deploy/target branches) on the repo.  An exception is made for the automated process
+# which is the only thing allowed to merge into master/etc.
 #
 # For emergencies, you can override this hook by using 'git commit -n'.
 
@@ -10,13 +10,35 @@
 # If you want to whitelist other users, just add another "-e <email>".
 SUPERUSERS="-e jenkins@khanacademy.org"
 
-if git config --get user.email | grep -x $SUPERUSERS >/dev/null; then
+
+# Exit if user email matches a SUPERUSER
+if git config --get user.email | grep -x "$SUPERUSERS" >/dev/null; then
     exit 0
 fi
 
-if [ "`git rev-parse --abbrev-ref HEAD`" = "master" ]; then
-   echo "FATAL ERROR: You cannot commit directly to the master branch."
-   echo "Commit to a deploy branch instead:"
-   echo "    https://khanacademy.org/r/git-at-ka"
-   exit 1
-fi
+# Get the current branch name
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Get the known deploy branches from the git config (comma-separated list)
+KNOWN_DEPLOY_BRANCHES=$(git config --get ka.olc.targetBranches)
+
+# Check if the current branch is protected
+case "$CURRENT_BRANCH" in
+    master|main|next|deploy*)
+        echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
+        echo "Make a pull-request or audit to a deploy branch instead: https://khanacademy.org/r/git-at-ka"
+        exit 1
+        ;;
+esac
+
+# Check if the current branch matches any known deploy branches
+IFS=','
+for branch in $KNOWN_DEPLOY_BRANCHES; do
+    if [ "$CURRENT_BRANCH" = "$branch" ]; then
+        echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
+        echo "Make a pull-request or audit to a deploy branch instead: https://khanacademy.org/r/git-at-ka"
+        exit 1
+    fi
+done
+
+exit 0

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -35,7 +35,7 @@ IFS=','
 for branch in $KNOWN_DEPLOY_BRANCHES; do
     if [ "$CURRENT_BRANCH" = "$branch" ]; then
         echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
-        echo "Make a pull-request or audit and land it to this branch instead"
+        echo "Make a pull-request (or audit) and land it to this branch instead"
         exit 1
     fi
 done

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -26,6 +26,7 @@ KNOWN_DEPLOY_BRANCHES=$(git config --get ka.olc.targetBranches)
 case "$CURRENT_BRANCH" in
     master|main|next|deploy*)
         echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
+        echo "More info: https://khanacademy.org/r/gitfaq#id-9e3a"
         exit 1
         ;;
 esac
@@ -36,6 +37,7 @@ for branch in $KNOWN_DEPLOY_BRANCHES; do
     if [ "$CURRENT_BRANCH" = "$branch" ]; then
         echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
         echo "Make a pull-request (or audit) and land it to this branch instead"
+        echo "More info: https://khanacademy.org/r/gitfaq#id-9e3a"
         exit 1
     fi
 done


### PR DESCRIPTION
## Summary:
Now it stops users from accidentally committing to `main`, a few other known branches (for mobile) and any of their target/deploy branches.

This can stop people from accidentally committing straight to a deploy branch, which 95% of the time, you never want to do. Can always just `git commit -n` if they _reallllly_ need to get around it (But they never should!! security reasons!! committing directly to a deploy branch bypasses PRs!! They should use an audit if they have to...) 

Issue: FEI-5966

## Test plan:
- See it fail when trying to commit on other branches, like `main`
- Use OLC to add a target branch, then try and commit to it directly, see it fail