### PR TITLE
Don't stop user from committing merge commits to deploy branches

### DIFF
--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -28,13 +28,8 @@ case "$CURRENT_BRANCH" in
         ;;
 esac
 
-# Check if we are in the middle of a merge
-if [ -f ".git/MERGE_HEAD" ]; then
-    exit 0
-fi
-
-# Check if we are in the middle of a rebase
-if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+# Check if we are in the middle of a merge or rebase.
+if [ -f ".git/MERGE_HEAD" -o -d ".git/rebase-merge" -o -d ".git/rebase-apply" ]; then
     exit 0
 fi
 

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -3,7 +3,7 @@
 # A simple pre-commit hook that makes it illegal to commit to master (and other
 # deploy/target branches) on the repo. One exception is made for the automated process
 # which is the only thing allowed to merge into master/etc. Another exception is made
-# for merge commits only, like if you have conflicts when updating your deploy branch.
+# for merge and rebase commits, like if you have conflicts when updating your deploy branch.
 #
 # For emergencies, you can override this hook by using 'git commit -n'.
 

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -29,10 +29,8 @@ case "$CURRENT_BRANCH" in
 esac
 
 # Exit if it's a merge commit
-if [ "$(git rev-parse --verify -q HEAD^)" ]; then
-    if [ "$(git rev-parse --verify -q HEAD^^)" ]; then
-        exit 0
-    fi
+if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -gt 2 ]; then
+    exit 0
 fi
 
 # Get the known deploy branches from the git config (comma-separated list)

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -29,7 +29,7 @@ case "$CURRENT_BRANCH" in
 esac
 
 # Check if we are in the middle of a merge or rebase.
-if [ -f ".git/MERGE_HEAD" -o -d ".git/rebase-merge" -o -d ".git/rebase-apply" ]; then
+if [ -f ".git/MERGE_HEAD" ] || [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
     exit 0
 fi
 

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -28,8 +28,15 @@ case "$CURRENT_BRANCH" in
         ;;
 esac
 
-# Exit if it's a merge commit
-if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -gt 2 ]; then
+# Check if we are in the middle of a merge
+if [ -f ".git/MERGE_HEAD" ]; then
+    exit 0
+fi
+
+# Check if we are in the middle of a rebase
+if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+    echo "Currently in the middle of a rebase."
+    # You can add additional logic here if needed.
     exit 0
 fi
 

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -35,13 +35,8 @@ fi
 
 # Check if we are in the middle of a rebase
 if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-    echo "Currently in the middle of a rebase."
-    # You can add additional logic here if needed.
     exit 0
 fi
-
-# Get the known deploy branches from the git config (comma-separated list)
-KNOWN_DEPLOY_BRANCHES=$(git config --get ka.olc.targetBranches)
 
 # Check if the current branch is protected in mobile or others
 case "$CURRENT_BRANCH" in
@@ -51,6 +46,9 @@ case "$CURRENT_BRANCH" in
         exit 1
         ;;
 esac
+
+# Get the known deploy branches from the git config (comma-separated list)
+KNOWN_DEPLOY_BRANCHES=$(git config --get ka.olc.targetBranches)
 
 # Check if the current branch matches any known deploy branches
 IFS=','

--- a/templates/pre-commit.protect-master
+++ b/templates/pre-commit.protect-master
@@ -1,8 +1,9 @@
 #!/bin/sh
 
 # A simple pre-commit hook that makes it illegal to commit to master (and other
-# deploy/target branches) on the repo.  An exception is made for the automated process
-# which is the only thing allowed to merge into master/etc.
+# deploy/target branches) on the repo. One exception is made for the automated process
+# which is the only thing allowed to merge into master/etc. Another exception is made
+# for merge commits only, like if you have conflicts when updating your deploy branch.
 #
 # For emergencies, you can override this hook by using 'git commit -n'.
 
@@ -19,12 +20,27 @@ fi
 # Get the current branch name
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+# Check if the current branch is `master` or `main`
+case "$CURRENT_BRANCH" in
+    master|main)
+        echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
+        exit 1
+        ;;
+esac
+
+# Exit if it's a merge commit
+if [ "$(git rev-parse --verify -q HEAD^)" ]; then
+    if [ "$(git rev-parse --verify -q HEAD^^)" ]; then
+        exit 0
+    fi
+fi
+
 # Get the known deploy branches from the git config (comma-separated list)
 KNOWN_DEPLOY_BRANCHES=$(git config --get ka.olc.targetBranches)
 
-# Check if the current branch is protected
+# Check if the current branch is protected in mobile or others
 case "$CURRENT_BRANCH" in
-    master|main|next)
+    next)
         echo "FATAL ERROR: You cannot commit directly to the $CURRENT_BRANCH branch."
         echo "More info: https://khanacademy.org/r/gitfaq#id-9e3a"
         exit 1


### PR DESCRIPTION
## Summary:
If I'm bringing in `master` or `main` and there's a merge conflict, I want to commit without using `-n`, because I want the rest of the verification things to happen.

Issue: FEI-5966

## Test plan:
Set up a lot of test branches and different combos of things, and test all cases
- Test committing to branches named `master`, `main`, and `next`
- Test committing to branches in your `targetBranches` list
- Test committing to branches that fit neither of these criteria
- Test merging a branch into `master`, `main`, with a conflict, that shouldn't work since you would be resolving those conflicts in the other branches
- Test rebasing a branch into `master`, `main`, with a conflict, that shouldn't work since you would be resolving those conflicts in the other branches
- Test merging into a known `targetBranch` with a conflict, see that you aren't stopped on the merge commit
- Test rebase into a known `targetBranch` with a conflict, see that you aren't stopped on the rebase commit