### PR TITLE
Don't overwrite `commit.template` or `include.path` if it is already set

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -85,6 +85,14 @@ def die_if_not_valid_git_repo():
     if revparse_retcode != 0:
         sys.exit(revparse_retcode)
 
+def _get_submodule_paths():
+    """Return a list of submodule paths."""
+    # We cannot use `git submodule foreach` since the submodules may
+    # not have been checked out yet.
+    all_submodules = subprocess.check_output(
+        ['git', 'submodule', 'status', '--recursive']
+    ).decode('utf-8')
+    return [l.split()[1] for l in all_submodules.splitlines()]
 
 def _run_in_main_repo_and_subrepos(cmd):
     """Run the given command in the main repo and all subrepos.
@@ -96,12 +104,7 @@ def _run_in_main_repo_and_subrepos(cmd):
     after the initial clone, they will not pick up the config setting.
     We'd have to hook into `git p` for that.  But it's better than nothing!
     """
-    # We cannot use `git submodule foreach` since the submodules may
-    # not have been checked out yet.
-    all_submodules = subprocess.check_output(
-        ['git', 'submodule', 'status', '--recursive']
-    ).decode('utf-8')
-    all_dirs = [l.split()[1] for l in all_submodules.splitlines()]
+    all_dirs = _get_submodule_paths()
     all_dirs.append('.')      # do the main repo as well!
 
     for subdir in all_dirs:
@@ -200,26 +203,62 @@ def _install_git_hook(template_name, destination_name):
     shutil.copy(src, dst)
     os.chmod(dst, (os.stat(dst)).st_mode | 0o111)  # ensure chmod +x
 
+def _existing_commit_template(cwd):
+    try:
+        template = subprocess.check_output(
+            ["git", "config", "commit.template"], cwd=cwd
+        ).decode('utf-8')
+        return template.strip()
+    except subprocess.CalledProcessError:
+        return None
+
 
 def link_commit_template():
     """If KA commit message template is installed, link it."""
-    _gitconfig_local_reference(
-        'commit.template',
-        os.path.join('.git_template', 'commit_template'),
-        "commit message template"
-    )
+    all_dirs = _get_submodule_paths()
+    all_dirs.append('.')      # do the main repo as well!
+
+    for subdir in all_dirs:
+        _gitconfig_relative_local_reference(
+            'commit.template',
+            os.path.join('.git_template', 'commit_template'),
+            "commit message template",
+            subdir
+        )
 
 
 def link_gitconfig_extras():
     """If KA gitconfig is installed, link it."""
-    _gitconfig_local_reference(
+    _gitconfig_recursive_local_reference(
         'include.path',
         '.gitconfig.khan',
         "KA gitconfig extras"
     )
+    
 
+def _gitconfig_relative_local_reference(config_key, location, name="reference", subpath):
+    home = os.path.expanduser("~")  # safe for cross platform
+    tmpl = os.path.join(home, location)
 
-def _gitconfig_local_reference(config_key, location, name="reference"):
+    existing = _existing_commit_template(subpath)
+    if existing:
+        if existing == tmpl:
+            _cli_log_step_success("Already linked {} in repo {}".format(name, subpath))
+            return
+        else:
+            _cli_log_step_warning("Repo {} already has a different {} linked. Skipping".format(subpath, name))
+            return
+
+    if os.path.isfile(tmpl):
+        subprocess.check_call( ['git', 'config', '--local', config_key, tmpl], cwd=subdir)
+        _cli_log_step_success("Linked {} in repo {}".format(name, subpath))
+    else:
+        msg = "{} not installed, skipping...".format(name)
+        # ugly hack to get capitalize() to work as desired
+        msg = msg[0].upper() + msg[1:]
+        _cli_log_step_warning(msg)
+
+def _gitconfig_recursive_local_reference(config_key, location, name="reference"):
     """Configure reference to userdir template, but only if exists.
 
     This also updates the gitconfig reference in submodules, since
@@ -227,6 +266,7 @@ def _gitconfig_local_reference(config_key, location, name="reference"):
     """
     home = os.path.expanduser("~")  # safe for cross platform
     tmpl = os.path.join(home, location)
+
     if os.path.isfile(tmpl):
         _run_in_main_repo_and_subrepos(
             ['git', 'config', '--local', config_key, tmpl]
@@ -335,7 +375,7 @@ if __name__ == '__main__':
 
     if args.repair:
         if args.src or args.dst:
-            parser.error("--repair takes no arguments")
+            parser.error("--repair takes no src or dst arguments")
             # TODO(mroth): allow --repair to take an optional target
         _cli_process_current_dir(args)
     else:

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -268,7 +268,7 @@ def link_commit_template():
     all_dirs.insert(0, '.')      # do the main repo as well!
 
     _cli_log_step_success(
-        "Linking commit message template ~/.git_template/commit_template"
+        "Linking commit message template ~/.git_template/commit_template..."
     )
 
     for subdir in all_dirs:
@@ -306,7 +306,7 @@ def _gitconfig_link_gitconfig_khan(config_key, location, subpath):
     repo ='current repo' if subpath == '.' else "repo {}".format(subpath)
 
     tmpl = _expanded_home_path(location)
-    existing = _existing_commit_template(subpath)
+    existing = _existing_config_includes(subpath)
 
     if tmpl in existing:
         _cli_log_step_warning(
@@ -337,7 +337,7 @@ def link_gitconfig_khan():
     all_dirs = _get_submodule_paths()
     all_dirs.insert(0, '.')      # do the main repo as well!
 
-    _cli_log_step_success("Including git config ~/.gitconfig.khan")
+    _cli_log_step_success("Including git config ~/.gitconfig.khan...")
 
     for subdir in all_dirs:
         _gitconfig_link_gitconfig_khan(

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -230,11 +230,10 @@ def _gitconfig_link_template(config_key, location, subpath):
     """
     repo ='current repo' if subpath == '.' else "repo {}".format(subpath)
 
-    tmpl = _expanded_home_path(location)
     existing = _existing_commit_template(subpath)
 
     if existing:
-        if existing == tmpl:
+        if existing == location:
             _cli_log_step_warning(
                 "The commit template is already linked in {}, skipping..."
                 .format(repo)
@@ -247,39 +246,41 @@ def _gitconfig_link_template(config_key, location, subpath):
             )
             return
 
-    if os.path.isfile(tmpl):
-        subprocess.check_call(
-            ['git', 'config', '--local', config_key, tmpl],
-            cwd=subpath
-        )
-        _cli_log_step_success(
-            "Linked commit message template {} in {}".format(tmpl, repo)
-        )
-    else:
-        _cli_log_step_warning(
-            "The commit template {} is not installed, ".format(tmpl) +
-            "so we can't link it, skipping..."
-        )
+    subprocess.check_call(
+        ['git', 'config', '--local', config_key, location],
+        cwd=subpath
+    )
+    _cli_log_step_success(
+        "Linked commit message template {} in {}".format(location, repo)
+    )
 
 
 def link_commit_template():
     """If KA commit message template is installed, link it."""
-    all_dirs = _get_submodule_paths()
-    all_dirs.insert(0, '.')      # do the main repo as well!
-
     _cli_log_step_success(
         "Linking commit message template ~/.git_template/commit_template..."
     )
 
+    tmpl = _expanded_home_path(os.path.join('.git_template', 'commit_template'))
+    if not os.path.isfile(tmpl):
+        _cli_log_step_warning(
+            "The commit template {} is not installed, ".format(tmpl) +
+            "so we can't link it, skipping..."
+        )
+        return
+
+    all_dirs = _get_submodule_paths()
+    all_dirs.insert(0, '.')      # do the main repo as well!
+
     for subdir in all_dirs:
         _gitconfig_link_template(
             'commit.template',
-            os.path.join('.git_template', 'commit_template'),
+            tmpl,
             subdir
         )
 
 
-def _existing_config_includes(cwd):
+def _existing_configs(cwd):
     try:
         incl = subprocess.check_output(
             ["git", "config", "--get-all","--local", "include.path"], cwd=cwd
@@ -305,44 +306,46 @@ def _gitconfig_link_gitconfig_khan(config_key, location, subpath):
     """
     repo ='current repo' if subpath == '.' else "repo {}".format(subpath)
 
-    tmpl = _expanded_home_path(location)
-    existing = _existing_config_includes(subpath)
+    existing = _existing_configs(subpath)
 
-    if tmpl in existing:
+    if location in existing:
         _cli_log_step_warning(
             "The git config is already included in {}, skipping..."
             .format(repo)
         )
         return
 
+    subprocess.check_call(
+        # Note: --add is used to allow multiple entries
+        ['git', 'config', '--add', '--local', config_key, location],
+        cwd=subpath
+    )
+    _cli_log_step_success(
+        "Included git config {} in {}".format(location, repo)
+    )
 
-    if os.path.isfile(tmpl):
-        subprocess.check_call(
-            # Note: --add is used to allow multiple entries
-            ['git', 'config', '--add', '--local', config_key, tmpl],
-            cwd=subpath
-        )
-        _cli_log_step_success(
-            "Included git config {} in {}".format(tmpl, repo)
-        )
-    else:
-        _cli_log_step_warning(
-            "The git config file {} is not installed, ".format(tmpl) +
-            "so we can't include it, skipping..."
-        )
 
 
 def link_gitconfig_khan():
     """If KA gitconfig is installed, link it."""
+    _cli_log_step_success("Including git config ~/.gitconfig.khan...")
+
+    tmpl = _expanded_home_path('.gitconfig.khan')
+    if not os.path.isfile(tmpl):
+        _cli_log_step_warning(
+            "The git config file {} is not installed, ".format(tmpl) +
+            "so we can't include it, skipping..."
+        )
+        return
+
     all_dirs = _get_submodule_paths()
     all_dirs.insert(0, '.')      # do the main repo as well!
-
-    _cli_log_step_success("Including git config ~/.gitconfig.khan...")
 
     for subdir in all_dirs:
         _gitconfig_link_gitconfig_khan(
             'include.path',
-            '.gitconfig.khan',subdir
+            tmpl,
+            subdir
         )
 
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -213,7 +213,7 @@ def _install_git_hook(template_name, destination_name):
 def _existing_commit_template(cwd):
     try:
         template = subprocess.check_output(
-            ["git", "config", "commit.template"], cwd=cwd
+            ["git", "config", "--local", "commit.template"], cwd=cwd
         ).decode('utf-8')
         return template.strip()
     except subprocess.CalledProcessError:
@@ -254,7 +254,8 @@ def _gitconfig_link_template(config_key, location, subpath):
         )
     else:
         _cli_log_step_warning(
-            "Commit message template {} is not installed, skipping...".format(tmpl)
+            "Commit message template {} is not installed, skipping..."
+            .format(tmpl)
         )
 
 
@@ -301,7 +302,7 @@ def _gitconfig_link_gitconfig_khan(config_key, location, name="reference"):
 
     if tmpl in existing:
         _cli_log_step_success(
-            "Already included .gitconfig.khan in repo {}"
+            "Already included git config {} in repo {}"
             .format(tmpl, subpath)
         )
         return
@@ -314,11 +315,12 @@ def _gitconfig_link_gitconfig_khan(config_key, location, name="reference"):
             cwd=subdir
         )
         _cli_log_step_success(
-            "Included .gitconfig.khan {} in repo {}".format(tmpl, subpath)
+            "Included git config {} in repo {}".format(tmpl, subpath)
         )
     else:
         _cli_log_step_warning(
-            "The config file {} is not installed, so we can't include it, skipping...".format(tmpl)
+            "The git config file {} is not installed, so we can't " +
+            "include it, skipping...".format(tmpl)
         )
 
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -16,6 +16,11 @@ TEMPLATES_DIR = os.path.join(
 )
 
 
+def _expanded_home_path(path):
+    home = os.path.expanduser("~")  # safe for cross platform
+    tmpl = os.path.join(home, path)
+
+
 def _cli_parser():
     parser = argparse.ArgumentParser(
         description='Clones and configures a KA repo.',
@@ -93,6 +98,7 @@ def _get_submodule_paths():
         ['git', 'submodule', 'status', '--recursive']
     ).decode('utf-8')
     return [l.split()[1] for l in all_submodules.splitlines()]
+
 
 def _run_in_main_repo_and_subrepos(cmd):
     """Run the given command in the main repo and all subrepos.
@@ -203,6 +209,7 @@ def _install_git_hook(template_name, destination_name):
     shutil.copy(src, dst)
     os.chmod(dst, (os.stat(dst)).st_mode | 0o111)  # ensure chmod +x
 
+
 def _existing_commit_template(cwd):
     try:
         template = subprocess.check_output(
@@ -213,70 +220,150 @@ def _existing_commit_template(cwd):
         return None
 
 
+def _gitconfig_link_template(config_key, location, subpath):
+    """Configure reference to commit template, but only if the file exists
+    and only if it isn't already set in the repo. We don't want to overwrite
+    anything.
+
+    This also updates the commit template reference in first-level submodules,
+    since `--local` does not cross submodule boundaries.
+    """
+    tmpl = _expanded_home_path(location)
+
+    existing = _existing_commit_template(subpath)
+    if existing:
+        if existing == tmpl:
+            _cli_log_step_success(
+                "Already linked commit message template {} in repo {}"
+                .format(tmpl, subpath)
+            )
+            return
+        else:
+            _cli_log_step_warning("Repo {} already has a commit message " +
+                "template linked ({}), skipping...".format(subpath, existing)
+            )
+            return
+
+    if os.path.isfile(tmpl):
+        subprocess.check_call(
+            ['git', 'config', '--local', config_key, tmpl],
+            cwd=subdir
+        )
+        _cli_log_step_success(
+            "Linked commit message template {} in repo {}".format(tmpl, subpath)
+        )
+    else:
+        _cli_log_step_warning(
+            "Commit message template {} is not installed, skipping...".format(tmpl)
+        )
+
+
 def link_commit_template():
     """If KA commit message template is installed, link it."""
     all_dirs = _get_submodule_paths()
     all_dirs.append('.')      # do the main repo as well!
 
     for subdir in all_dirs:
-        _gitconfig_relative_local_reference(
+        _gitconfig_link_template(
             'commit.template',
             os.path.join('.git_template', 'commit_template'),
-            "commit message template",
             subdir
         )
 
 
-def link_gitconfig_extras():
-    """If KA gitconfig is installed, link it."""
-    _gitconfig_recursive_local_reference(
-        'include.path',
-        '.gitconfig.khan',
-        "KA gitconfig extras"
-    )
-    
+def _existing_config_includes(cwd):
+    try:
+        incl = subprocess.check_output(
+            ["git", "config", "--get-all","--local", "include.path"], cwd=cwd
+        ).decode('utf-8').strip()
+        return (
+            [line.strip() for line in incl.splitlines()] if incl else []
+        )
+    except subprocess.CalledProcessError:
+        return []
 
-def _gitconfig_relative_local_reference(config_key, location, name="reference", subpath):
-    home = os.path.expanduser("~")  # safe for cross platform
-    tmpl = os.path.join(home, location)
+
+def _gitconfig_link_gitconfig_khan(config_key, location, name="reference"):
+    """Configure reference to gitconfig.khan. This adds a new include.path
+    line to the local gitconfig, as opposed to overwriting the existing one.
+    Only do this if the file exists and there isn't already a local
+    include.path set to the same value. Note, this is how git-config
+    works with the include.path option. You can have multiple entries, so
+    we don't have to worry about overwriting existing ones, but it does get
+    tricky if you have two entries that are set to the same value.
+
+    This also updates the gitconfig reference in first-level submodules,
+    since `--local` does not cross submodule boundaries.
+    """
+    tmpl = _expanded_home_path(location)
 
     existing = _existing_commit_template(subpath)
-    if existing:
-        if existing == tmpl:
-            _cli_log_step_success("Already linked {} in repo {}".format(name, subpath))
-            return
-        else:
-            _cli_log_step_warning("Repo {} already has a different {} linked. Skipping".format(subpath, name))
-            return
 
-    if os.path.isfile(tmpl):
-        subprocess.check_call( ['git', 'config', '--local', config_key, tmpl], cwd=subdir)
-        _cli_log_step_success("Linked {} in repo {}".format(name, subpath))
-    else:
-        msg = "{} not installed, skipping...".format(name)
-        # ugly hack to get capitalize() to work as desired
-        msg = msg[0].upper() + msg[1:]
-        _cli_log_step_warning(msg)
-
-def _gitconfig_recursive_local_reference(config_key, location, name="reference"):
-    """Configure reference to userdir template, but only if exists.
-
-    This also updates the gitconfig reference in submodules, since
-    `--local` does not cross submodule boundaries.
-    """
-    home = os.path.expanduser("~")  # safe for cross platform
-    tmpl = os.path.join(home, location)
-
-    if os.path.isfile(tmpl):
-        _run_in_main_repo_and_subrepos(
-            ['git', 'config', '--local', config_key, tmpl]
+    if tmpl in existing:
+        _cli_log_step_success(
+            "Already included .gitconfig.khan in repo {}"
+            .format(tmpl, subpath)
         )
-        _cli_log_step_success("Linked {}".format(name))
+        return
+
+
+    if os.path.isfile(tmpl):
+        subprocess.check_call(
+            # Note: --add is used to allow multiple entries
+            ['git', 'config', '--add', '--local', config_key, tmpl],
+            cwd=subdir
+        )
+        _cli_log_step_success(
+            "Included .gitconfig.khan {} in repo {}".format(tmpl, subpath)
+        )
     else:
-        msg = "{} not installed, skipping...".format(name)
-        # ugly hack to get capitalize() to work as desired
-        msg = msg[0].upper() + msg[1:]
-        _cli_log_step_warning(msg)
+        _cli_log_step_warning(
+            "The config file {} is not installed, so we can't include it, skipping...".format(tmpl)
+        )
+
+
+#     existing = _existing_commit_template(subpath)
+#     if existing:
+#         if existing == tmpl:
+#             _cli_log_step_success("Already linked {} in repo {}".format(name, subpath))
+#             return
+#         else:
+#             _cli_log_step_warning("Repo {} already has a different {} linked. Skipping".format(subpath, name))
+#             return
+#
+#     if os.path.isfile(tmpl):
+#         subprocess.check_call( ['git', 'config', '--local', config_key, tmpl], cwd=subdir)
+#         _cli_log_step_success("Linked {} in repo {}".format(name, subpath))
+#     else:
+#         msg = "{} not installed, skipping...".format(name)
+#         # ugly hack to get capitalize() to work as desired
+#         msg = msg[0].upper() + msg[1:]
+#         _cli_log_step_warning(msg)
+#
+#
+#     if os.path.isfile(tmpl):
+#         _run_in_main_repo_and_subrepos(
+#             ['git', 'config', '--local', config_key, tmpl]
+#         )
+#         _cli_log_step_success("Linked {}".format(name))
+#     else:
+#         msg = "{} not installed, skipping...".format(name)
+#         # ugly hack to get capitalize() to work as desired
+#         msg = msg[0].upper() + msg[1:]
+#         _cli_log_step_warning(msg)
+
+
+def link_gitconfig_khan():
+    """If KA gitconfig is installed, link it."""
+    all_dirs = _get_submodule_paths()
+    all_dirs.append('.')      # do the main repo as well!
+
+    for subdir in all_dirs:
+        _gitconfig_link_gitconfig_khan(
+            'include.path',
+            '.gitconfig.khan',
+            "KA gitconfig extras"
+        )
 
 
 def _clone_repo(src, dst, quiet=False):
@@ -346,7 +433,7 @@ def _cli_process_current_dir(cli_args):
     if not cli_args.no_msg:
         link_commit_template()
     if not cli_args.no_gitconfig:
-        link_gitconfig_extras()
+        link_gitconfig_khan()
 
     if cli_args.protect_master:
         protect_master()

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -18,7 +18,7 @@ TEMPLATES_DIR = os.path.join(
 
 def _expanded_home_path(path):
     home = os.path.expanduser("~")  # safe for cross platform
-    tmpl = os.path.join(home, path)
+    return os.path.join(home, path)
 
 
 def _cli_parser():
@@ -228,41 +228,48 @@ def _gitconfig_link_template(config_key, location, subpath):
     This also updates the commit template reference in first-level submodules,
     since `--local` does not cross submodule boundaries.
     """
-    tmpl = _expanded_home_path(location)
+    repo ='current repo' if subpath == '.' else "repo {}".format(subpath)
 
+    tmpl = _expanded_home_path(location)
     existing = _existing_commit_template(subpath)
+
     if existing:
         if existing == tmpl:
-            _cli_log_step_success(
-                "Already linked commit message template {} in repo {}"
-                .format(tmpl, subpath)
+            _cli_log_step_warning(
+                "The commit template is already linked in {}, skipping..."
+                .format(repo)
             )
             return
         else:
-            _cli_log_step_warning("Repo {} already has a commit message " +
-                "template linked ({}), skipping...".format(subpath, existing)
+            _cli_log_step_warning(
+                "The {} already has a commit message ".format(repo) +
+                "template linked ({}), skipping...".format(existing)
             )
             return
 
     if os.path.isfile(tmpl):
         subprocess.check_call(
             ['git', 'config', '--local', config_key, tmpl],
-            cwd=subdir
+            cwd=subpath
         )
         _cli_log_step_success(
-            "Linked commit message template {} in repo {}".format(tmpl, subpath)
+            "Linked commit message template {} in {}".format(tmpl, repo)
         )
     else:
         _cli_log_step_warning(
-            "Commit message template {} is not installed, skipping..."
-            .format(tmpl)
+            "The commit template {} is not installed, ".format(tmpl) +
+            "so we can't link it, skipping..."
         )
 
 
 def link_commit_template():
     """If KA commit message template is installed, link it."""
     all_dirs = _get_submodule_paths()
-    all_dirs.append('.')      # do the main repo as well!
+    all_dirs.insert(0, '.')      # do the main repo as well!
+
+    _cli_log_step_success(
+        "Linking commit message template ~/.git_template/commit_template"
+    )
 
     for subdir in all_dirs:
         _gitconfig_link_template(
@@ -284,7 +291,7 @@ def _existing_config_includes(cwd):
         return []
 
 
-def _gitconfig_link_gitconfig_khan(config_key, location, name="reference"):
+def _gitconfig_link_gitconfig_khan(config_key, location, subpath):
     """Configure reference to gitconfig.khan. This adds a new include.path
     line to the local gitconfig, as opposed to overwriting the existing one.
     Only do this if the file exists and there isn't already a local
@@ -296,14 +303,15 @@ def _gitconfig_link_gitconfig_khan(config_key, location, name="reference"):
     This also updates the gitconfig reference in first-level submodules,
     since `--local` does not cross submodule boundaries.
     """
-    tmpl = _expanded_home_path(location)
+    repo ='current repo' if subpath == '.' else "repo {}".format(subpath)
 
+    tmpl = _expanded_home_path(location)
     existing = _existing_commit_template(subpath)
 
     if tmpl in existing:
-        _cli_log_step_success(
-            "Already included git config {} in repo {}"
-            .format(tmpl, subpath)
+        _cli_log_step_warning(
+            "The git config is already included in {}, skipping..."
+            .format(repo)
         )
         return
 
@@ -312,59 +320,29 @@ def _gitconfig_link_gitconfig_khan(config_key, location, name="reference"):
         subprocess.check_call(
             # Note: --add is used to allow multiple entries
             ['git', 'config', '--add', '--local', config_key, tmpl],
-            cwd=subdir
+            cwd=subpath
         )
         _cli_log_step_success(
-            "Included git config {} in repo {}".format(tmpl, subpath)
+            "Included git config {} in {}".format(tmpl, repo)
         )
     else:
         _cli_log_step_warning(
-            "The git config file {} is not installed, so we can't " +
-            "include it, skipping...".format(tmpl)
+            "The git config file {} is not installed, ".format(tmpl) +
+            "so we can't include it, skipping..."
         )
-
-
-#     existing = _existing_commit_template(subpath)
-#     if existing:
-#         if existing == tmpl:
-#             _cli_log_step_success("Already linked {} in repo {}".format(name, subpath))
-#             return
-#         else:
-#             _cli_log_step_warning("Repo {} already has a different {} linked. Skipping".format(subpath, name))
-#             return
-#
-#     if os.path.isfile(tmpl):
-#         subprocess.check_call( ['git', 'config', '--local', config_key, tmpl], cwd=subdir)
-#         _cli_log_step_success("Linked {} in repo {}".format(name, subpath))
-#     else:
-#         msg = "{} not installed, skipping...".format(name)
-#         # ugly hack to get capitalize() to work as desired
-#         msg = msg[0].upper() + msg[1:]
-#         _cli_log_step_warning(msg)
-#
-#
-#     if os.path.isfile(tmpl):
-#         _run_in_main_repo_and_subrepos(
-#             ['git', 'config', '--local', config_key, tmpl]
-#         )
-#         _cli_log_step_success("Linked {}".format(name))
-#     else:
-#         msg = "{} not installed, skipping...".format(name)
-#         # ugly hack to get capitalize() to work as desired
-#         msg = msg[0].upper() + msg[1:]
-#         _cli_log_step_warning(msg)
 
 
 def link_gitconfig_khan():
     """If KA gitconfig is installed, link it."""
     all_dirs = _get_submodule_paths()
-    all_dirs.append('.')      # do the main repo as well!
+    all_dirs.insert(0, '.')      # do the main repo as well!
+
+    _cli_log_step_success("Including git config ~/.gitconfig.khan")
 
     for subdir in all_dirs:
         _gitconfig_link_gitconfig_khan(
             'include.path',
-            '.gitconfig.khan',
-            "KA gitconfig extras"
+            '.gitconfig.khan',subdir
         )
 
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -42,7 +42,7 @@ def _cli_parser():
                         help='install hooks to protect the master branch')
     parser.add_argument('--branch-name-hook',
                         action='store_true',
-                        help='prepend commit-msgs with the current branch name')
+                        help='prepend commit-msgs with current branch name')
     parser.add_argument('--lint-commit',
                         action='store_true',
                         help='hook up commit-msg linting')
@@ -90,6 +90,7 @@ def die_if_not_valid_git_repo():
     if revparse_retcode != 0:
         sys.exit(revparse_retcode)
 
+
 def _get_submodule_paths():
     """Return a list of submodule paths."""
     # We cannot use `git submodule foreach` since the submodules may
@@ -97,7 +98,7 @@ def _get_submodule_paths():
     all_submodules = subprocess.check_output(
         ['git', 'submodule', 'status', '--recursive']
     ).decode('utf-8')
-    return [l.split()[1] for l in all_submodules.splitlines()]
+    return [line.split()[1] for line in all_submodules.splitlines()]
 
 
 def _run_in_main_repo_and_subrepos(cmd):
@@ -228,7 +229,7 @@ def _gitconfig_link_template(config_key, location, subpath):
     This also updates the commit template reference in first-level submodules,
     since `--local` does not cross submodule boundaries.
     """
-    repo ='current repo' if subpath == '.' else "repo {}".format(subpath)
+    repo = 'current repo' if subpath == '.' else "repo {}".format(subpath)
 
     existing = _existing_commit_template(subpath)
 
@@ -261,7 +262,9 @@ def link_commit_template():
         "Linking commit message template ~/.git_template/commit_template..."
     )
 
-    tmpl = _expanded_home_path(os.path.join('.git_template', 'commit_template'))
+    tmpl = _expanded_home_path(
+        os.path.join('.git_template', 'commit_template'))
+
     if not os.path.isfile(tmpl):
         _cli_log_step_warning(
             "The commit template {} is not installed, ".format(tmpl) +
@@ -283,7 +286,7 @@ def link_commit_template():
 def _existing_configs(cwd):
     try:
         incl = subprocess.check_output(
-            ["git", "config", "--get-all","--local", "include.path"], cwd=cwd
+            ["git", "config", "--get-all", "--local", "include.path"], cwd=cwd
         ).decode('utf-8').strip()
         return (
             [line.strip() for line in incl.splitlines()] if incl else []
@@ -304,7 +307,7 @@ def _gitconfig_link_gitconfig_khan(config_key, location, subpath):
     This also updates the gitconfig reference in first-level submodules,
     since `--local` does not cross submodule boundaries.
     """
-    repo ='current repo' if subpath == '.' else "repo {}".format(subpath)
+    repo = 'current repo' if subpath == '.' else "repo {}".format(subpath)
 
     existing = _existing_configs(subpath)
 
@@ -323,7 +326,6 @@ def _gitconfig_link_gitconfig_khan(config_key, location, subpath):
     _cli_log_step_success(
         "Included git config {} in {}".format(location, repo)
     )
-
 
 
 def link_gitconfig_khan():


### PR DESCRIPTION
## Summary:
We don't want `ka-clone` to overwrite or duplicate any **local** values the user may have already set for `commit.template` and `include.path`, when running with `--repair`. So check if they are already set, and skip if they are!

NOTE: There is a quirk with `include.path`. This config option can have multiple values! You can _add_ new values with the command `git config --local --add include.path <path>`. 
```
global  file:/Users/lilli/.gitconfig    /Users/lilli/.gitconfig.khan
local   file:.git/config        /Users/lilli/.gitconfig.khan-xtra
local   file:.git/config        /Users/lilli/.gitconfig.khan
```

BUT (!!) if you do this twice with the same path-string, it's super annoying to change or unset. If each path-string is in there only once (locally or globally), you can unset that specific path with the command `git config --unset [--local|--global] include.path <EXACT-STRING-TO-SINGLE-VALUE>`.

If you have a duplicate, you get this:
```
% git config --unset --local include.path /Users/lilli/.gitconfig.khan    
warning: include.path has multiple values
```
This doesn't cross local/global boundary when that flag is explicitly used.

This behavior means that, for `include.path`, we can _append_ new things, but we have to be careful not to duplicate stuff.

Since the behavior was different between the `commit.template` value, and the `include path` value, I split the function `_gitconfig_local_reference` into two functions. We also want to be safe when we do set these for our submodules, so I had to move the submodule loop to the outside of the check.

![Screenshot 2024-11-14 at 12 50 41 PM](https://github.com/user-attachments/assets/8087ae93-4961-4e39-81a8-3c29aba96686)

![Screenshot 2024-11-14 at 12 50 28 PM](https://github.com/user-attachments/assets/d8f1c972-70c3-4dce-9e68-76a92d251ef3)



Issue: FEI-5987

## Test plan:
I set up a repo with a few submodules...

Commit template tests
- Test nothing set locally for `commit.template` → **this should set the value**
- Test `~/.git_template/commit_template` is set locally → should skip [tilde path] 
- Test `/Users/lilli/.git_template/commit_template` is set locally → should skip [expanded path] 
- Test `./.git_template/commit_template` is set locally → should skip [same but local ref]
- Test `<some other path>` is set locally → should skip [other value]
- All the above use-cases should work the same even if we have something globally set for `commit.template`
- Test various tests above for submodules too
- Test when dotfile isn't installed in home dir

Git config tests
- Test nothing set locally for `include.path` → **this should append the value**
- Test `~/.gitconfig.khan` is set locally → should skip it, because git config resolves this to the expanded value [tilde path] 
- Test `/Users/lilli/.gitconfig.khan` is set locally → it should skip this [expanded path] 
- Test `./.gitconfig.khan` is set locally → should still append it, since it's different than expanded value [same but local ref]
- Test `<some other path>` is set locally → should still append it [other value]
- All the above use-cases should work the same even if we have something globally set for `include.path`
- Test various tests above for submodules too
- Test when dotfile isn't installed in home dir