### PR TITLE
Change the defaults of ka-clone and reorder things slightly

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -39,15 +39,27 @@ def _cli_parser():
                         action='store_true',
                         help='attempt to khanify the current directory')
     # enable/disable functions
-    parser.add_argument('-p', '--protect-master',
+    group_protect_master = parser.add_mutually_exclusive_group()
+    group_protect_master.add_argument('-p', '--protect-master',
                         action='store_true',
                         help='install hooks to protect the master branch')
-    parser.add_argument('--branch-name-hook',
+    group_protect_master.add_argument('--no-protect-master',
+                        action='store_true',
+                        help='do not install hooks to protect the master branch')
+    group_branch_name = parser.add_mutually_exclusive_group()
+    group_branch_name.add_argument('--branch-name-hook',
                         action='store_true',
                         help='prepend commit-msgs with current branch name')
-    parser.add_argument('--lint-commit',
+    group_branch_name.add_argument('--no-branch-name-hook',
+                        action='store_true',
+                        help='do not add hook to prepend commit-msgs with current branch name')
+    group_lint_commit = parser.add_mutually_exclusive_group()
+    group_lint_commit.add_argument('--lint-commit',
                         action='store_true',
                         help='hook up commit-msg linting')
+    group_lint_commit.add_argument('--no-lint-commit',
+                        action='store_true',
+                        help='do not hook up commit-msg linting')
     parser.add_argument('--no-email',
                         action='store_true',
                         help='do not override user.email')
@@ -482,18 +494,22 @@ def _chomp(s, sep):
 def _cli_process_current_dir(cli_args):
     die_if_not_valid_git_repo()
 
-    backup_existing_hooks()
-
     if not cli_args.no_email:
         set_email(args.email)
-    if not cli_args.no_lint:
-        install_pre_push_lint_hook()
+
     if not cli_args.no_msg:
         link_commit_template()
     if not cli_args.no_gitconfig:
         link_gitconfig_khan()
 
-    if cli_args.protect_master:
+    backup_existing_hooks()
+
+    if not cli_args.no_lint:
+        install_pre_push_lint_hook()
+    else:
+        _remove_git_hook('pre-push.lint')
+
+    if cli_args.protect_master or not cli_args.no_protect_master:
         protect_master()
 
     if cli_args.lint_commit:
@@ -502,7 +518,7 @@ def _cli_process_current_dir(cli_args):
     else:
         _remove_git_hook('commit-msg.lint')
 
-    if cli_args.branch_name_hook:
+    if cli_args.branch_name_hook or not cli_args.no_branch_name_hook:
         _install_git_hook('commit-msg.branch-name', 'commit-msg.branch-name')
         _cli_log_step_success("Added commit-msg branch-name hook")
     else:

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -39,43 +39,34 @@ def _cli_parser():
                         action='store_true',
                         help='attempt to khanify the current directory')
     # enable/disable functions
-    group_protect_master = parser.add_mutually_exclusive_group()
-    group_protect_master.add_argument('-p', '--protect-master',
-                                      action='store_true',
-                                      help='install hooks to protect ' +
-                                           'the master branch')
-    group_protect_master.add_argument('--no-protect-master',
-                                      action='store_true',
-                                      help='do not install hooks to ' +
-                                           'protect the master branch')
-    group_branch_name = parser.add_mutually_exclusive_group()
-    group_branch_name.add_argument('--branch-name-hook',
-                                   action='store_true',
-                                   help='prepend commit-msgs with ' +
-                                        'current branch name')
-    group_branch_name.add_argument('--no-branch-name-hook',
-                                   action='store_true',
-                                   help='do not add hook to prepend commit-' +
-                                        'msgs with current branch name')
-    group_lint_commit = parser.add_mutually_exclusive_group()
-    group_lint_commit.add_argument('--lint-commit',
-                                   action='store_true',
-                                   help='hook up commit-msg linting')
-    group_lint_commit.add_argument('--no-lint-commit',
-                                   action='store_true',
-                                   help='do not hook up commit-msg linting')
+    parser.add_argument('-p', '--protect-master',
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help='install hooks to protect the master branch')
+    parser.add_argument('--branch-name-hook',
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help='prepend commit-msgs with current branch name')
+    parser.add_argument('--lint-commit',
+                        action=argparse.BooleanOptionalAction,
+                        default=False,
+                        help='hook up commit-msg linting')
     parser.add_argument('--no-email',
                         action='store_true',
                         help='do not override user.email')
-    parser.add_argument('--no-gitconfig',
-                        action='store_true',
-                        help='do not link KA gitconfig extras')
-    parser.add_argument('--no-lint',
-                        action='store_true',
-                        help='do not hook pre-push linting')
-    parser.add_argument('--no-msg',
-                        action='store_true',
-                        help='no commit message template')
+    parser.add_argument('--gitconfig',
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help='link KA gitconfig extras')
+    parser.add_argument('--lint',
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help='hook up pre-push linting')
+    parser.add_argument('--msg',
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help='set the khan commit message template')
+
     # default values
     parser.add_argument('--email',
                         help="email address to use (default: %(default)s)",
@@ -501,32 +492,27 @@ def _cli_process_current_dir(cli_args):
     if not cli_args.no_email:
         set_email(args.email)
 
-    if not cli_args.no_msg:
+    if cli_args.msg:
         link_commit_template()
-    if not cli_args.no_gitconfig:
+
+    if cli_args.gitconfig:
         link_gitconfig_khan()
 
     backup_existing_hooks()
 
-    if not cli_args.no_lint:
+    if cli_args.lint:
         install_pre_push_lint_hook()
-    else:
-        _remove_git_hook('pre-push.lint')
 
-    if cli_args.protect_master or not cli_args.no_protect_master:
+    if cli_args.protect_master:
         protect_master()
 
     if cli_args.lint_commit:
         _install_git_hook('commit-msg.lint', 'commit-msg.lint')
         _cli_log_step_success("Added commit-msg lint hook")
-    else:
-        _remove_git_hook('commit-msg.lint')
 
-    if cli_args.branch_name_hook or not cli_args.no_branch_name_hook:
+    if cli_args.branch_name_hook:
         _install_git_hook('commit-msg.branch-name', 'commit-msg.branch-name')
         _cli_log_step_success("Added commit-msg branch-name hook")
-    else:
-        _remove_git_hook('commit-msg.branch-name')
 
     install_global_git_hooks()
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -41,25 +41,29 @@ def _cli_parser():
     # enable/disable functions
     group_protect_master = parser.add_mutually_exclusive_group()
     group_protect_master.add_argument('-p', '--protect-master',
-                        action='store_true',
-                        help='install hooks to protect the master branch')
+                                      action='store_true',
+                                      help='install hooks to protect ' +
+                                           'the master branch')
     group_protect_master.add_argument('--no-protect-master',
-                        action='store_true',
-                        help='do not install hooks to protect the master branch')
+                                      action='store_true',
+                                      help='do not install hooks to ' +
+                                           'protect the master branch')
     group_branch_name = parser.add_mutually_exclusive_group()
     group_branch_name.add_argument('--branch-name-hook',
-                        action='store_true',
-                        help='prepend commit-msgs with current branch name')
+                                   action='store_true',
+                                   help='prepend commit-msgs with ' +
+                                        'current branch name')
     group_branch_name.add_argument('--no-branch-name-hook',
-                        action='store_true',
-                        help='do not add hook to prepend commit-msgs with current branch name')
+                                   action='store_true',
+                                   help='do not add hook to prepend commit-' +
+                                        'msgs with current branch name')
     group_lint_commit = parser.add_mutually_exclusive_group()
     group_lint_commit.add_argument('--lint-commit',
-                        action='store_true',
-                        help='hook up commit-msg linting')
+                                   action='store_true',
+                                   help='hook up commit-msg linting')
     group_lint_commit.add_argument('--no-lint-commit',
-                        action='store_true',
-                        help='do not hook up commit-msg linting')
+                                   action='store_true',
+                                   help='do not hook up commit-msg linting')
     parser.add_argument('--no-email',
                         action='store_true',
                         help='do not override user.email')


### PR DESCRIPTION
## Summary:
I also added some "opposite" args in arg groups (e.g., `--protect-master` and `--no-protect-master`), which users can't use at the same time.

So, the defaults are now (currently):
```
Option               | Is Default?
---------------------+-----------
use ka email         | yes
protect master hooks | yes
branch name hook     | yes
lint commit msg hook | no
pre-push lint hook   | yes
git config linked    | yes
commit template      | yes
```

@csilvers are these defaults good? Do you think I should toggle any of them? This is what I landed on after I started the implementation.

Should I rename these args to be a little more consistent with each other and their function? I don't love how they currently are (e.g., `--no-msg` meaning "don't use the ka commit template" and `--no-lint` referring to the pre-push linter but not the commit-msg linter), but don't know who else may have hard-coded them as they currently are. (Or if it's worth doing.)

Issue: FEI-6001

## Test plan:
- Run `ka-clone` with no args, sees that the defaults are what we are saying they are
- Run with conflicting arguments (e.g., `--protect-master` and `--no-protect-master`), and see that it errors
- Try running with all arguments that are opposite of the deep faults and see that they do what we expect them to do