### PR TITLE
Add a version arg to `ka-clone`

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -39,15 +39,27 @@ def _cli_parser():
                         action='store_true',
                         help='attempt to khanify the current directory')
     # enable/disable functions
-    parser.add_argument('-p', '--protect-master',
+    group_protect_master = parser.add_mutually_exclusive_group()
+    group_protect_master.add_argument('-p', '--protect-master',
                         action='store_true',
                         help='install hooks to protect the master branch')
-    parser.add_argument('--branch-name-hook',
+    group_protect_master.add_argument('--no-protect-master',
+                        action='store_true',
+                        help='do not install hooks to protect the master branch')
+    group_branch_name = parser.add_mutually_exclusive_group()
+    group_branch_name.add_argument('--branch-name-hook',
                         action='store_true',
                         help='prepend commit-msgs with current branch name')
-    parser.add_argument('--lint-commit',
+    group_branch_name.add_argument('--no-branch-name-hook',
+                        action='store_true',
+                        help='do not add hook to prepend commit-msgs with current branch name')
+    group_lint_commit = parser.add_mutually_exclusive_group()
+    group_lint_commit.add_argument('--lint-commit',
                         action='store_true',
                         help='hook up commit-msg linting')
+    group_lint_commit.add_argument('--no-lint-commit',
+                        action='store_true',
+                        help='do not hook up commit-msg linting')
     parser.add_argument('--no-email',
                         action='store_true',
                         help='do not override user.email')
@@ -482,18 +494,22 @@ def _chomp(s, sep):
 def _cli_process_current_dir(cli_args):
     die_if_not_valid_git_repo()
 
-    backup_existing_hooks()
-
     if not cli_args.no_email:
         set_email(args.email)
-    if not cli_args.no_lint:
-        install_pre_push_lint_hook()
+
     if not cli_args.no_msg:
         link_commit_template()
     if not cli_args.no_gitconfig:
         link_gitconfig_khan()
 
-    if cli_args.protect_master:
+    backup_existing_hooks()
+
+    if not cli_args.no_lint:
+        install_pre_push_lint_hook()
+    else:
+        _remove_git_hook('pre-push.lint')
+
+    if cli_args.protect_master or not cli_args.no_protect_master:
         protect_master()
 
     if cli_args.lint_commit:
@@ -502,7 +518,7 @@ def _cli_process_current_dir(cli_args):
     else:
         _remove_git_hook('commit-msg.lint')
 
-    if cli_args.branch_name_hook:
+    if cli_args.branch_name_hook or not cli_args.no_branch_name_hook:
         _install_git_hook('commit-msg.branch-name', 'commit-msg.branch-name')
         _cli_log_step_success("Added commit-msg branch-name hook")
     else:

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -24,8 +24,6 @@ def _expanded_home_path(path):
 
 
 def _cli_parser():
-
-
     parser = argparse.ArgumentParser(
         description='Clones and configures a KA repo.',
         usage=_cli_usage())

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -24,9 +24,24 @@ def _expanded_home_path(path):
 
 
 def _cli_parser():
+
+
     parser = argparse.ArgumentParser(
         description='Clones and configures a KA repo.',
         usage=_cli_usage())
+    # NOTE(Lilli): Please make sure that the version is always an integer,
+    # and that it stays in sync with the version in the OLC file
+    # https://github.com/Khan/our-lovely-cli/blob/main/cmd/repo-rangers/ranger-version.ts
+    # called KA_CLONE_EXPECTED_VERSION. If you change any of the arguments
+    # listed here, in a way that isn't backwards-compatible with what OLC
+    # is trying to do, please bump the version number here and update OLC
+    # to work correctly with the new args. OLC auto-updates itself, so that
+    # should be all you need to do.
+
+    # version
+    parser.add_argument('--version',
+                        action='version',
+                        version='1')
     # positional arguments
     parser.add_argument('src',
                         help=argparse.SUPPRESS,
@@ -83,7 +98,7 @@ def _cli_parser():
     # preferences
     parser.add_argument('-q', '--quiet',
                         action='store_true',
-                        help='silence succcess messages')
+                        help='silence success messages')
     return parser
 
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -41,25 +41,29 @@ def _cli_parser():
     # enable/disable functions
     group_protect_master = parser.add_mutually_exclusive_group()
     group_protect_master.add_argument('-p', '--protect-master',
-                        action='store_true',
-                        help='install hooks to protect the master branch')
+                                      action='store_true',
+                                      help='install hooks to protect ' +
+                                           'the master branch')
     group_protect_master.add_argument('--no-protect-master',
-                        action='store_true',
-                        help='do not install hooks to protect the master branch')
+                                      action='store_true',
+                                      help='do not install hooks to ' +
+                                           'protect the master branch')
     group_branch_name = parser.add_mutually_exclusive_group()
     group_branch_name.add_argument('--branch-name-hook',
-                        action='store_true',
-                        help='prepend commit-msgs with current branch name')
+                                   action='store_true',
+                                   help='prepend commit-msgs with ' +
+                                        'current branch name')
     group_branch_name.add_argument('--no-branch-name-hook',
-                        action='store_true',
-                        help='do not add hook to prepend commit-msgs with current branch name')
+                                   action='store_true',
+                                   help='do not add hook to prepend commit-' +
+                                        'msgs with current branch name')
     group_lint_commit = parser.add_mutually_exclusive_group()
     group_lint_commit.add_argument('--lint-commit',
-                        action='store_true',
-                        help='hook up commit-msg linting')
+                                   action='store_true',
+                                   help='hook up commit-msg linting')
     group_lint_commit.add_argument('--no-lint-commit',
-                        action='store_true',
-                        help='do not hook up commit-msg linting')
+                                   action='store_true',
+                                   help='do not hook up commit-msg linting')
     parser.add_argument('--no-email',
                         action='store_true',
                         help='do not override user.email')


### PR DESCRIPTION
## Summary:
This is used by OLC to make sure that the correct version of ka-clone is installed, so that when OLC uses any of the newly added args (#15), the script doesn't error. OLC will try and pull down the latest version of ka-clone if the user isn't on it.


Issue: FEI-6006

## Test plan:
Try `ka-clone --version` and see the output of `1`