### PR TITLE
Rename the flags so they are clearer and more consistent with each other

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -44,12 +44,12 @@ def _cli_parser():
                         default=True,
                         help='install hooks to protect the master branch')
     parser.add_argument('--commit-msg-branch-name',
-                        '--branch-name-hook', # old, obsolete name
+                        '--branch-name-hook',  # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='prepend commit-msgs with current branch name')
     parser.add_argument('--commit-msg-lint',
-                        '--lint-commit', # old, obsolete name
+                        '--lint-commit',  # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=False,
                         help='hook up commit-msg linting')
@@ -61,12 +61,12 @@ def _cli_parser():
                         default=True,
                         help='link KA gitconfig extras')
     parser.add_argument('--pre-push-lint',
-                        '--lint', # old, obsolete name
+                        '--lint',  # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='hook up pre-push linting')
     parser.add_argument('--commit-msg-template',
-                        '--msg', # old, obsolete name
+                        '--msg',  # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='set the khan commit message template')

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -43,11 +43,11 @@ def _cli_parser():
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='install hooks to protect the master branch')
-    parser.add_argument('--branch-name-hook',
+    parser.add_argument('--commit-msg-branch-name',
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='prepend commit-msgs with current branch name')
-    parser.add_argument('--lint-commit',
+    parser.add_argument('--commit-msg-lint',
                         action=argparse.BooleanOptionalAction,
                         default=False,
                         help='hook up commit-msg linting')
@@ -58,11 +58,11 @@ def _cli_parser():
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='link KA gitconfig extras')
-    parser.add_argument('--lint',
+    parser.add_argument('--pre-push-lint',
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='hook up pre-push linting')
-    parser.add_argument('--msg',
+    parser.add_argument('--commit-msg-template',
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='set the khan commit message template')
@@ -74,7 +74,7 @@ def _cli_parser():
     # preferences
     parser.add_argument('-q', '--quiet',
                         action='store_true',
-                        help='silence succcess messages')
+                        help='silence success messages')
     return parser
 
 
@@ -492,7 +492,7 @@ def _cli_process_current_dir(cli_args):
     if not cli_args.no_email:
         set_email(args.email)
 
-    if cli_args.msg:
+    if cli_args.commit_msg_template:
         link_commit_template()
 
     if cli_args.gitconfig:
@@ -500,17 +500,17 @@ def _cli_process_current_dir(cli_args):
 
     backup_existing_hooks()
 
-    if cli_args.lint:
+    if cli_args.pre_push_lint:
         install_pre_push_lint_hook()
 
     if cli_args.protect_master:
         protect_master()
 
-    if cli_args.lint_commit:
+    if cli_args.commit_msg_lint:
         _install_git_hook('commit-msg.lint', 'commit-msg.lint')
         _cli_log_step_success("Added commit-msg lint hook")
 
-    if cli_args.branch_name_hook:
+    if cli_args.commit_msg_branch_name:
         _install_git_hook('commit-msg.branch-name', 'commit-msg.branch-name')
         _cli_log_step_success("Added commit-msg branch-name hook")
 

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -44,10 +44,12 @@ def _cli_parser():
                         default=True,
                         help='install hooks to protect the master branch')
     parser.add_argument('--commit-msg-branch-name',
+                        '--branch-name-hook', # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='prepend commit-msgs with current branch name')
     parser.add_argument('--commit-msg-lint',
+                        '--lint-commit', # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=False,
                         help='hook up commit-msg linting')
@@ -59,10 +61,12 @@ def _cli_parser():
                         default=True,
                         help='link KA gitconfig extras')
     parser.add_argument('--pre-push-lint',
+                        '--lint', # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='hook up pre-push linting')
     parser.add_argument('--commit-msg-template',
+                        '--msg', # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=True,
                         help='set the khan commit message template')


### PR DESCRIPTION
## Summary:
The previous args were short, and that was nice, but they didn't really map to what each arg was doing inside the script, and this muddiness was adding cognitive load. Now the names are longer, but consistent with each other and clearer for the reader.

Issue: FEI-6060

## Test plan:
Run ka-clone [--repair] with all args and make sure they work