### PR TITLE
If run in webapp, follow with make hooks

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -23,6 +23,23 @@ def _expanded_home_path(path):
     return os.path.join(home, path)
 
 
+def _git_dir():
+    """Retrieve the GIT_DIR from the system."""
+    return subprocess.check_output(
+        ["git", "rev-parse", "--git-dir"]
+    ).decode('utf-8').rstrip()
+
+
+def _top_level_dir():
+    """Retrieve the top-level directory of the git repo
+    e.g., '/path/to/webapp' or '/path/to/mobile', even if
+    called from a subdirectory.
+    """
+    return subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"]
+    ).decode('utf-8').rstrip()
+
+
 def _cli_parser():
     parser = argparse.ArgumentParser(
         description='Clones and configures a KA repo.',
@@ -114,6 +131,10 @@ def die_if_not_valid_git_repo():
         sys.exit(revparse_retcode)
 
 
+def is_webapp_repo():
+    return os.path.basename(_top_level_dir()) == "webapp"
+
+
 def _get_submodule_paths():
     """Return a list of submodule paths."""
     # We cannot use `git submodule foreach` since the submodules may
@@ -197,13 +218,6 @@ def install_pre_push_lint_hook():
     _cli_log_step_success("Added pre-push linting hook")
 
 
-def _git_dir():
-    """Retrieve the GIT_DIR from the system."""
-    return subprocess.check_output(
-        ["git", "rev-parse", "--git-dir"]
-    ).decode('utf-8').rstrip()
-
-
 def backup_existing_hooks():
     """Backup existing hooks in the git hooks directory."""
 
@@ -264,6 +278,26 @@ def install_global_git_hooks():
     # found here https://khanacademy.org/r/gitfaq#id-3c30
     _install_git_hook('pre-push', 'pre-push')
     _install_git_hook('commit-msg', 'commit-msg')
+
+
+def run_webapp_make_hooks():
+    _cli_log_step_success("Running make hooks because this repo is webapp...")
+    # Must run in top-level folder, even if this is called in subdirectory
+
+    p = subprocess.Popen(
+        ['make', 'hooks'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=_top_level_dir()
+    )
+    out, err = p.communicate()
+
+    if p.returncode != 0:
+        _cli_log_step_indented_info("Failed to run make hooks")
+        _cli_log_step_indented_info("Error: {}".format(err.decode('utf-8')))
+    else:
+        _cli_log_step_indented_info("Ran make hooks successfully")
+
 
 
 def _remove_git_hook(destination_name):
@@ -519,6 +553,9 @@ def _cli_process_current_dir(cli_args):
         _cli_log_step_success("Added commit-msg branch-name hook")
 
     install_global_git_hooks()
+
+    if is_webapp_repo():
+        run_webapp_make_hooks()
 
 
 if __name__ == '__main__':

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -131,10 +131,6 @@ def die_if_not_valid_git_repo():
         sys.exit(revparse_retcode)
 
 
-def is_webapp_repo():
-    return os.path.basename(_top_level_dir()) == "webapp"
-
-
 def _get_submodule_paths():
     """Return a list of submodule paths."""
     # We cannot use `git submodule foreach` since the submodules may
@@ -280,7 +276,12 @@ def install_global_git_hooks():
     _install_git_hook('commit-msg', 'commit-msg')
 
 
-def run_webapp_make_hooks():
+def can_run_make_hooks():
+    if os.path.exists(os.path.join(_top_level_dir(), "Makefile")):
+        return "\nhooks: " in open(os.path.join(_top_level_dir(), "Makefile")).read()
+
+
+def run_make_hooks():
     _cli_log_step_success("Running make hooks because this repo is webapp...")
     # Must run in top-level folder, even if this is called in subdirectory
 
@@ -553,8 +554,8 @@ def _cli_process_current_dir(cli_args):
 
     install_global_git_hooks()
 
-    if is_webapp_repo():
-        run_webapp_make_hooks()
+    if can_run_make_hooks():
+        run_make_hooks()
 
 
 if __name__ == '__main__':

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -278,27 +278,25 @@ def install_global_git_hooks():
 
 def can_run_make_hooks():
     if os.path.exists(os.path.join(_top_level_dir(), "Makefile")):
-        return ("\nhooks: " in
-                open(os.path.join(_top_level_dir(), "Makefile")).read())
+        with open(os.path.join(_top_level_dir(), "Makefile")) as f:
+            body = f.read()
+            return re.search(r'^hooks:', body, flags=re.MULTILINE)
+
+    return False
 
 
 def run_make_hooks():
-    _cli_log_step_success("Running make hooks because this repo is webapp...")
+    _cli_log_step_success("Running make hooks because this repo has make hooks...")
+
     # Must run in top-level folder, even if this is called in subdirectory
-
-    p = subprocess.Popen(
-        ['make', 'hooks'],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=_top_level_dir()
-    )
-    out, err = p.communicate()
-
-    if p.returncode != 0:
-        _cli_log_step_indented_info("Failed to run make hooks")
-        _cli_log_step_indented_info("Error: {}".format(err.decode('utf-8')))
-    else:
+    try:
+        subprocess.check_output(['make', 'hooks'],
+                                stderr=subprocess.STDOUT,
+                                cwd=_top_level_dir())
         _cli_log_step_indented_info("Ran make hooks successfully")
+    except subprocess.CalledProcessError as e:
+        _cli_log_step_indented_info("Failed to run make hooks")
+        print("\nError: {}".format(e.output.decode('utf-8')))
 
 
 def _remove_git_hook(destination_name):

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -286,7 +286,7 @@ def can_run_make_hooks():
 
 
 def run_make_hooks():
-    _cli_log_step_success("Running make hooks because this repo has make hooks...")
+    _cli_log_step_success("Running make hooks...")
 
     # Must run in top-level folder, even if this is called in subdirectory
     try:

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -299,7 +299,6 @@ def run_webapp_make_hooks():
         _cli_log_step_indented_info("Ran make hooks successfully")
 
 
-
 def _remove_git_hook(destination_name):
     """Remove a git hook from the CWD's git repo."""
     hooks_dir = os.path.join(_git_dir(), "hooks")

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -278,7 +278,8 @@ def install_global_git_hooks():
 
 def can_run_make_hooks():
     if os.path.exists(os.path.join(_top_level_dir(), "Makefile")):
-        return "\nhooks: " in open(os.path.join(_top_level_dir(), "Makefile")).read()
+        return ("\nhooks: " in
+                open(os.path.join(_top_level_dir(), "Makefile")).read())
 
 
 def run_make_hooks():


### PR DESCRIPTION
## Summary:
In webapp, we also have the `post-rewrite`, `post-merge`, and `post-checkout` hooks, which get added by `make hooks`. Since I changed ka-clone to move/backup the `.git/hooks` directory (to `.git/hooks.backup_TTTT-TT-TTTTT:TT:TT:TT`), those get moved out. 

Not sure what calls `make hooks` in the webapp process, but it is something that is noticeable when calling `ka-clone` through OLC's Repo Rangers, because that module shows the before/after of the hooks dir before `make hooks` gets called again.

Here's the weird OLC output:
![Screenshot 2025-01-06 at 12 11 42 PM](https://github.com/user-attachments/assets/5f24bc6f-89cf-4d0b-a568-241cb8b38472)


So, since there's already `make hooks`, of course `ka-clone` should call it for webapp.

Successful `ka-clone` run:
![Screenshot 2025-01-06 at 12 12 12 PM](https://github.com/user-attachments/assets/7580a8d0-ec5f-4226-9bb4-5fc7b2bcdbd3)

Unsuccessful `ka-clone` run:
![Screenshot 2025-01-06 at 12 13 07 PM](https://github.com/user-attachments/assets/abe6ff1a-1ee2-4904-a03f-ac3f10b99d28)


Issue: FEI-6078

## Test plan:
- Test in webapp, at top level dir
- Test in webapp, not at top level dir
- Test in a different repo
- Put gobbledy-gook in webapps Makefile so it errors and test that too