### PR TITLE
Pipe ka-clone's logging to stdout and stderr depending on level so other scripts can parse non-fatal errors

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -169,7 +169,7 @@ def _default_email():
         ).decode('utf-8')
         return kac_email.rstrip()
     except subprocess.CalledProcessError:
-        EXIT_CODE = 1
+        SHARED_RET_CODE = 1
         return os.environ['USER'] + "@" + DEFAULT_EMAIL_DOMAIN
 
 
@@ -297,7 +297,7 @@ def run_make_hooks():
                                 cwd=_top_level_dir())
         _cli_log_step_indented_info("Ran make hooks successfully")
     except subprocess.CalledProcessError as e:
-        EXIT_CODE = 1
+        SHARED_RET_CODE = 1
         _cli_log_step_indented_info("Failed to run make hooks")
         print("\nError: {}".format(e.output.decode('utf-8')))
 
@@ -331,7 +331,7 @@ def _existing_commit_template(cwd):
         ).decode('utf-8')
         return template.strip()
     except subprocess.CalledProcessError:
-        EXIT_CODE = 1
+        SHARED_RET_CODE = 1
         return None
 
 
@@ -385,7 +385,7 @@ def link_commit_template():
             "The commit template {}".format(tmpl),
             "is not installed, so we can't link it, skipping..."
         )
-        EXIT_CODE = 1
+        SHARED_RET_CODE = 1
         return
 
     all_dirs = _get_submodule_paths()
@@ -409,7 +409,7 @@ def _existing_configs(cwd):
             [line.strip() for line in incl.splitlines()] if incl else []
         )
     except subprocess.CalledProcessError:
-        EXIT_CODE = 1
+        SHARED_RET_CODE = 1
         return []
 
 
@@ -452,7 +452,7 @@ def link_gitconfig_khan():
 
     tmpl = _expanded_home_path('.gitconfig.khan')
     if not os.path.isfile(tmpl):
-        EXIT_CODE = 1
+        SHARED_RET_CODE = 1
         _cli_log_step_indented_info(
             "The git config file {} is not installed, ".format(tmpl) +
             "so we can't include it, skipping..."

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -17,7 +17,6 @@ TEMPLATES_DIR = os.path.join(
     "templates"
 )
 
-SHARED_RET_CODE = 0
 
 def _expanded_home_path(path):
     home = os.path.expanduser("~")  # safe for cross platform
@@ -169,8 +168,8 @@ def _default_email():
         ).decode('utf-8')
         return kac_email.rstrip()
     except subprocess.CalledProcessError:
-        global SHARED_RET_CODE
-        SHARED_RET_CODE = 1
+        # Send to stderr
+        logging.error('** No git email set')
         return os.environ['USER'] + "@" + DEFAULT_EMAIL_DOMAIN
 
 
@@ -298,8 +297,8 @@ def run_make_hooks():
                                 cwd=_top_level_dir())
         _cli_log_step_indented_info("Ran make hooks successfully")
     except subprocess.CalledProcessError as e:
-        global SHARED_RET_CODE
-        SHARED_RET_CODE = 1
+        # Send to stderr
+        logging.error('** Failed to run make hooks')
         _cli_log_step_indented_info("Failed to run make hooks")
         print("\nError: {}".format(e.output.decode('utf-8')))
 
@@ -333,8 +332,8 @@ def _existing_commit_template(cwd):
         ).decode('utf-8')
         return template.strip()
     except subprocess.CalledProcessError:
-        global SHARED_RET_CODE
-        SHARED_RET_CODE = 1
+        # Send to stderr
+        logging.error('** Failed to get git config --local commit.template')
         return None
 
 
@@ -388,8 +387,10 @@ def link_commit_template():
             "The commit template {}".format(tmpl),
             "is not installed, so we can't link it, skipping..."
         )
-        global SHARED_RET_CODE
-        SHARED_RET_CODE = 1
+        # Send to stderr
+        logging.error(
+            '** The commit template {} is not installed'.format(tmpl)
+        )
         return
 
     all_dirs = _get_submodule_paths()
@@ -413,8 +414,8 @@ def _existing_configs(cwd):
             [line.strip() for line in incl.splitlines()] if incl else []
         )
     except subprocess.CalledProcessError:
-        global SHARED_RET_CODE
-        SHARED_RET_CODE = 1
+        # Send to stderr
+        logging.error('** Failed to get-all git config --local include.path')
         return []
 
 
@@ -457,8 +458,10 @@ def link_gitconfig_khan():
 
     tmpl = _expanded_home_path('.gitconfig.khan')
     if not os.path.isfile(tmpl):
-        global SHARED_RET_CODE
-        SHARED_RET_CODE = 1
+        # Send to stderr
+        logging.error(
+            '** The git config file {} is not installed'.format(tmpl)
+        )
         _cli_log_step_indented_info(
             "The git config file {} is not installed, ".format(tmpl) +
             "so we can't include it, skipping..."
@@ -574,8 +577,39 @@ if __name__ == '__main__':
     parser = _cli_parser()
     args = parser.parse_args()
 
-    logging.basicConfig(format="%(message)s")
-    logging.getLogger().setLevel(logging.ERROR if args.quiet else logging.INFO)
+    # logger = logging.getLogger("nameOfTheLogger")
+    # ConsoleOutputHandler = logging.StreamHandler()
+    #
+    # logger.addHandler(ConsoleOutputHandler)
+    #
+    # logger.warning("Warning.")
+
+    logger = logging.getLogger()
+    # logger.setLevel(logging.DEBUG if args.quiet else logging.INFO)
+    logger.setLevel(logging.DEBUG)
+    format='%(message)s'
+    formatter = logging.Formatter(format)
+
+    h1 = logging.NullHandler() if args.quiet else logging.StreamHandler(sys.stdout)
+    # logging.getLogger().setLevel(logging.DEBUG if args.quiet else logging.INFO)
+    h1.setLevel(logging.INFO)
+    h1.addFilter(lambda record: record.levelno <= logging.INFO)
+    h1.setFormatter(formatter)
+
+    h2 = logging.StreamHandler()
+    h2.setLevel(logging.WARNING)
+    h2.setFormatter(formatter)
+    logger.addHandler(h1)
+    logger.addHandler(h2)
+    logger.info("info")
+    logger.error("error")
+
+
+    # logging.basicConfig(stream=sys.stdout, format="%(message)s", level=logging.INFO)
+    # logging.basicConfig(stream=sys.stderr, format="%(message)s", level=logging.ERROR)
+    # logging.basicConfig(stream=sys.stdout, level=[logging.DEBUG, logging.INFO])
+    # logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    # logging.getLogger().setLevel(logging.DEBUG if args.quiet else logging.INFO)
 
     if args.repair:
         if args.src or args.dst:
@@ -593,5 +627,3 @@ if __name__ == '__main__':
         )
         os.chdir(_dst)
         _cli_process_current_dir(args)
-
-    sys.exit(SHARED_RET_CODE)

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -17,6 +17,7 @@ TEMPLATES_DIR = os.path.join(
     "templates"
 )
 
+SHARED_RET_CODE = 0
 
 def _expanded_home_path(path):
     home = os.path.expanduser("~")  # safe for cross platform
@@ -168,6 +169,7 @@ def _default_email():
         ).decode('utf-8')
         return kac_email.rstrip()
     except subprocess.CalledProcessError:
+        EXIT_CODE = 1
         return os.environ['USER'] + "@" + DEFAULT_EMAIL_DOMAIN
 
 
@@ -295,6 +297,7 @@ def run_make_hooks():
                                 cwd=_top_level_dir())
         _cli_log_step_indented_info("Ran make hooks successfully")
     except subprocess.CalledProcessError as e:
+        EXIT_CODE = 1
         _cli_log_step_indented_info("Failed to run make hooks")
         print("\nError: {}".format(e.output.decode('utf-8')))
 
@@ -328,6 +331,7 @@ def _existing_commit_template(cwd):
         ).decode('utf-8')
         return template.strip()
     except subprocess.CalledProcessError:
+        EXIT_CODE = 1
         return None
 
 
@@ -381,6 +385,7 @@ def link_commit_template():
             "The commit template {}".format(tmpl),
             "is not installed, so we can't link it, skipping..."
         )
+        EXIT_CODE = 1
         return
 
     all_dirs = _get_submodule_paths()
@@ -404,6 +409,7 @@ def _existing_configs(cwd):
             [line.strip() for line in incl.splitlines()] if incl else []
         )
     except subprocess.CalledProcessError:
+        EXIT_CODE = 1
         return []
 
 
@@ -446,6 +452,7 @@ def link_gitconfig_khan():
 
     tmpl = _expanded_home_path('.gitconfig.khan')
     if not os.path.isfile(tmpl):
+        EXIT_CODE = 1
         _cli_log_step_indented_info(
             "The git config file {} is not installed, ".format(tmpl) +
             "so we can't include it, skipping..."
@@ -580,3 +587,5 @@ if __name__ == '__main__':
         )
         os.chdir(_dst)
         _cli_process_current_dir(args)
+
+    sys.exit(SHARED_RET_CODE)

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -579,10 +579,12 @@ if __name__ == '__main__':
 
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
-    format='%(message)s'
+    format = '%(message)s'
     formatter = logging.Formatter(format)
 
-    h1 = logging.NullHandler() if args.quiet else logging.StreamHandler(sys.stdout)
+    h1 = logging.NullHandler() if args.quiet \
+        else logging.StreamHandler(sys.stdout)
+
     h1.setLevel(logging.INFO)
     h1.addFilter(lambda record: record.levelno <= logging.INFO)
     h1.setFormatter(formatter)

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -577,21 +577,12 @@ if __name__ == '__main__':
     parser = _cli_parser()
     args = parser.parse_args()
 
-    # logger = logging.getLogger("nameOfTheLogger")
-    # ConsoleOutputHandler = logging.StreamHandler()
-    #
-    # logger.addHandler(ConsoleOutputHandler)
-    #
-    # logger.warning("Warning.")
-
     logger = logging.getLogger()
-    # logger.setLevel(logging.DEBUG if args.quiet else logging.INFO)
     logger.setLevel(logging.DEBUG)
     format='%(message)s'
     formatter = logging.Formatter(format)
 
     h1 = logging.NullHandler() if args.quiet else logging.StreamHandler(sys.stdout)
-    # logging.getLogger().setLevel(logging.DEBUG if args.quiet else logging.INFO)
     h1.setLevel(logging.INFO)
     h1.addFilter(lambda record: record.levelno <= logging.INFO)
     h1.setFormatter(formatter)
@@ -601,15 +592,6 @@ if __name__ == '__main__':
     h2.setFormatter(formatter)
     logger.addHandler(h1)
     logger.addHandler(h2)
-    logger.info("info")
-    logger.error("error")
-
-
-    # logging.basicConfig(stream=sys.stdout, format="%(message)s", level=logging.INFO)
-    # logging.basicConfig(stream=sys.stderr, format="%(message)s", level=logging.ERROR)
-    # logging.basicConfig(stream=sys.stdout, level=[logging.DEBUG, logging.INFO])
-    # logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-    # logging.getLogger().setLevel(logging.DEBUG if args.quiet else logging.INFO)
 
     if args.repair:
         if args.src or args.dst:

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -169,6 +169,7 @@ def _default_email():
         ).decode('utf-8')
         return kac_email.rstrip()
     except subprocess.CalledProcessError:
+        global SHARED_RET_CODE
         SHARED_RET_CODE = 1
         return os.environ['USER'] + "@" + DEFAULT_EMAIL_DOMAIN
 
@@ -297,6 +298,7 @@ def run_make_hooks():
                                 cwd=_top_level_dir())
         _cli_log_step_indented_info("Ran make hooks successfully")
     except subprocess.CalledProcessError as e:
+        global SHARED_RET_CODE
         SHARED_RET_CODE = 1
         _cli_log_step_indented_info("Failed to run make hooks")
         print("\nError: {}".format(e.output.decode('utf-8')))
@@ -331,6 +333,7 @@ def _existing_commit_template(cwd):
         ).decode('utf-8')
         return template.strip()
     except subprocess.CalledProcessError:
+        global SHARED_RET_CODE
         SHARED_RET_CODE = 1
         return None
 
@@ -385,6 +388,7 @@ def link_commit_template():
             "The commit template {}".format(tmpl),
             "is not installed, so we can't link it, skipping..."
         )
+        global SHARED_RET_CODE
         SHARED_RET_CODE = 1
         return
 
@@ -409,6 +413,7 @@ def _existing_configs(cwd):
             [line.strip() for line in incl.splitlines()] if incl else []
         )
     except subprocess.CalledProcessError:
+        global SHARED_RET_CODE
         SHARED_RET_CODE = 1
         return []
 
@@ -452,6 +457,7 @@ def link_gitconfig_khan():
 
     tmpl = _expanded_home_path('.gitconfig.khan')
     if not os.path.isfile(tmpl):
+        global SHARED_RET_CODE
         SHARED_RET_CODE = 1
         _cli_log_step_indented_info(
             "The git config file {} is not installed, ".format(tmpl) +


### PR DESCRIPTION
## Summary:

If ka-clone hits an issue that isn't worth killing the process over, log it to stderr, otherwise log the rest to stdout. Needed to redirect python's logging from stderr to stdout

ssue: FEI-6095

## Test plan:
- For errors, see it in stderr
- See rest in std out
- See quiet only outputs errors