### PR TITLE
Change the word 'prepend' to 'label' since that seems easier to understand and friendlier

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -64,7 +64,7 @@ def _cli_parser():
                         '--branch-name-hook',  # old, obsolete name
                         action=argparse.BooleanOptionalAction,
                         default=True,
-                        help='prepend commit-msgs with current branch name')
+                        help='label commit-msgs with current branch name')
     parser.add_argument('--commit-msg-lint',
                         '--lint-commit',  # old, obsolete name
                         action=argparse.BooleanOptionalAction,


### PR DESCRIPTION
## Summary:
Seems more casual and approachable:
> "Hey, this tool labels your commits for you so you can shuffle them easier!"

versus:
> "Hey, this tool prepends your commit messages for you so you can use that to shuffle the commits easier!"

Issue: FEI-XXXX

## Test plan:
`ka-clone --help`