### PR TITLE
Toggle the default for --pre-push-lint from true to false

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -80,7 +80,7 @@ def _cli_parser():
     parser.add_argument('--pre-push-lint',
                         '--lint',  # old, obsolete name
                         action=argparse.BooleanOptionalAction,
-                        default=True,
+                        default=False,
                         help='hook up pre-push linting')
     parser.add_argument('--commit-msg-template',
                         '--msg',  # old, obsolete name


### PR DESCRIPTION
## Summary:
[See the Slack thread here for more context](https://khanacademy.slack.com/archives/C06P903SXV3/p1746624684972699). Basically, installing the pre-push linter should be default `off` in most contexts other than webapp, so this PR toggles that.

Related PRs:
- https://github.com/Khan/khan-dotfiles/pull/145
- https://github.com/Khan/ka-clone/pull/23 👈 you are here
- https://github.com/Khan/ka-clone/pull/24
- https://github.com/Khan/our-lovely-cli/pull/1000
- https://github.com/Khan/our-lovely-cli/pull/1001

Issue: FEI-6625

## Test plan:
- Run `ka-clone --repair` in a repo, see that the hook ISN'T installed in `.git/hooks`
- Run `ka-clone --repair --pre-push-lint` in a repo, see that the hook IS installed in `.git/hooks`