### PR TITLE
Add a version arg for use by Repo Rangers

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -48,6 +48,8 @@ def _cli_parser():
     # NOTE(Lilli): Please make sure that the version is always an integer,
     # as it is used by Repo Rangers in the OLC repo to determine if the
     # version of KA-clone is compatible with the version of OLC.
+    # repo: https://github.com/Khan/our-lovely-cli
+    # file: ./cmd/repo-rangers/ranger-version.ts#L2
 
     # version
     parser.add_argument('--version',

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -44,6 +44,16 @@ def _cli_parser():
     parser = argparse.ArgumentParser(
         description='Clones and configures a KA repo.',
         usage=_cli_usage())
+
+    # NOTE(Lilli): Please make sure that the version is always an integer,
+    # as it is used by Repo Rangers in the OLC repo to determine if the
+    # version of KA-clone is compatible with the version of OLC.
+
+    # version
+    parser.add_argument('--version',
+                        action='version',
+                        version='1')
+
     # positional arguments
     parser.add_argument('src',
                         help=argparse.SUPPRESS,


### PR DESCRIPTION
## Summary:
[See the Slack thread here for more context](https://khanacademy.slack.com/archives/C06P903SXV3/p1746624684972699).

Before, to see if we are on the right version of `ka-clone`, Repo Rangers would check if the flags it needed were present. If they weren't, rrs would just need to update ka-clone to the latest version.

But now we are making a change to ka-clone that end up *not changing* any of ka-clone's flags (it just toggles a default), so for this change, we can no longer rely on the presence/absence of flags to determine if ka-clone is up to date. Instead, we will *also* need use a --version flag to check the version of ka-clone.

Related PRs:
- https://github.com/Khan/khan-dotfiles/pull/145
- https://github.com/Khan/ka-clone/pull/23
- https://github.com/Khan/ka-clone/pull/24 👈 you are here
- https://github.com/Khan/our-lovely-cli/pull/1000
- https://github.com/Khan/our-lovely-cli/pull/1001

Issue: FEI-6625

## Test plan:
Run `ka-clone --version` and see `1`