### PR TITLE
feat: shorthand syntax for cloning from khan

### DIFF
--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -485,6 +485,11 @@ def _clone_repo(src, dst, quiet=False):
     if dst is None:
         dst = _guess_dst_name(src)
 
+    # Format src as Khan GitHub repo if it's just a simple name
+    if not any(src.startswith(prefix) for prefix in
+               ['git@', 'ssh://', 'http://', 'https://']):
+        src = f'git@github.com:Khan/{src}.git'
+
     cmds = ['git', 'clone']
     # we want the subprocess to be quiet too
     if quiet:

--- a/bin/ka-clone
+++ b/bin/ka-clone
@@ -486,8 +486,7 @@ def _clone_repo(src, dst, quiet=False):
         dst = _guess_dst_name(src)
 
     # Format src as Khan GitHub repo if it's just a simple name
-    if not any(src.startswith(prefix) for prefix in
-               ['git@', 'ssh://', 'http://', 'https://']):
+    if not src.startswith(('git@', 'ssh://', 'http://', 'https://')):
         src = f'git@github.com:Khan/{src}.git'
 
     cmds = ['git', 'clone']


### PR DESCRIPTION
## Summary:
Adds a hub/gh like shorthand for cloning repos. It's already a khan specific
tool, so hardcoded the behavior when no repo prefixes are specified.

Issue: XXX-XXXX

## Test plan:

ran it locally
```
zaq@schoolbox:~/projects/khan
$ ka-clone districts-jobs
Cloning into 'districts-jobs'...
remote: Enumerating objects: 45986, done.
remote: Counting objects: 100% (1464/1464), done.
remote: Compressing objects: 100% (471/471), done.
remote: Total 45986 (delta 1281), reused 994 (delta 993), pack-reused 44522 (from 3)
Receiving objects: 100% (45986/45986), 45.48 MiB | 10.81 MiB/s, done.
Resolving deltas: 100% (37657/37657), done.
Configuring your cloned git repository with KA defaults...
-> Set user.email to zaq@khanacademy.org
-> Linking commit message template ~/.git_template/commit_template...
-> Linked commit message template
    /home/zaq/.git_template/commit_template in current repo

-> Including git config ~/.gitconfig.khan...
-> Included git config /home/zaq/.gitconfig.khan in current repo

-> Backing up existing hooks...
    *** Backed up existing hooks to .git/hooks.backup_2025-07-11T12:09:04
    *** More info: https://khanacademy.org/r/gitfaq#id-3c30

-> Created new hooks directory at .git/hooks
-> Added hooks to protect master branch
-> Added commit-msg branch-name hook

```